### PR TITLE
Introduce augmentations for generic containers

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022 Josh Martinez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Augmentations for the `Array` and `ReadonlyArray` types, and tuple literals.
+ *
+ * ## Importing this module
+ *
+ * This module's augmentations can be applied by using the following import:
+ *
+ * ```ts
+ * import "@neotype/instances/array.js";
+ * ```
+ *
+ * ## Comparing `Array` and `ReadonlyArray`
+ *
+ * `Array` and `ReadonlyArray` implement `Eq` and `Ord` when their elements
+ * implement `Eq` and `Ord`, respectively.
+ *
+ * - Two arrays are equal if they are the same length and their respective
+ *   elements are equal.
+ * - Arrays are ordered lexicographically.
+ * - Read-only and non-read-only arrays can be compared to each other.
+ *
+ * ## `Array` and `ReadonlyArray` as semigroups
+ *
+ * `Array` and `ReadonlyArray` implement `Semigroup`.
+ *
+ * - Arrays are combined using concatenation.
+ * - Read-only and non-read-only arrays can be combined with each other.
+ * - If either array is read-only, the resulting array will also be read-only.
+ *
+ * ## Comparing tuple literals
+ *
+ * Tuple literals implement `Eq` and `Ord` when their elements implement `Eq`
+ * and `Ord`, respectively.
+ *
+ * - Two tuple literals are equal if they are the same length and their
+ *   respective elements are equal.
+ * - Tuple literals are ordered lexicographically.
+ * - Read-only and non-read-only tuples can be compared to each other.
+ *
+ * @module
+ */
+
+import { Semigroup } from "@neotype/prelude/cmb.js";
+import { Eq, icmp, ieq, Ord, type Ordering } from "@neotype/prelude/cmp.js";
+
+declare global {
+    interface Array<T> {
+        [Eq.eq]<T extends Eq<T>>(this: T[], that: T[]): boolean;
+
+        [Ord.cmp]<T extends Ord<T>>(this: T[], that: T[]): Ordering;
+
+        [Semigroup.cmb](that: T[]): T[];
+    }
+
+    interface ReadonlyArray<T> {
+        [Eq.eq]<T extends Eq<T>>(
+            this: readonly T[],
+            that: readonly T[],
+        ): boolean;
+
+        [Ord.cmp]<T extends Ord<T>>(
+            this: readonly T[],
+            that: readonly T[],
+        ): Ordering;
+
+        [Semigroup.cmb](that: readonly T[]): T[];
+    }
+}
+
+Array.prototype[Eq.eq] = function <T extends Eq<T>>(
+    this: readonly T[],
+    that: readonly T[],
+): boolean {
+    return ieq(this, that);
+};
+
+Array.prototype[Ord.cmp] = function <T extends Ord<T>>(
+    this: T[],
+    that: T[],
+): Ordering {
+    return icmp(this, that);
+};
+
+Array.prototype[Semigroup.cmb] = function <T>(that: T[]): T[] {
+    return [...this, ...that];
+};

--- a/src/map.ts
+++ b/src/map.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 Josh Martinez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Augmentations for the `Map` and `ReadonlyMap` types.
+ *
+ * ## Importing this module
+ *
+ * This module's augmentations can be applied by using the following import:
+ *
+ * ```ts
+ * import "@neotype/instances/map.js";
+ * ```
+ *
+ * ## Comparing `Map` and `ReadonlyMap`
+ *
+ * `Map` and `ReadonlyMap` implement `Eq`.
+ *
+ * - Two maps are equal if they are the same size and contain the same key-value
+ *   pairs.
+ * - Keys and values are compared using strict equality (`===`).
+ * - Read-only and non-read-only maps can be compared to each other.
+ *
+ * ## `Map` and `ReadonlyMap` as semigroups
+ *
+ * `Map` and `ReadonlyMap` implement `Semigroup`.
+ *
+ * - Maps are combined by taking their union.
+ * - Duplicate values are determined using strict equality (`===`).
+ * - If a key is mapped to two different values, only the right-hand map's value
+ *   is retained.
+ * - Read-only and non-read-only maps can be combined with each other.
+ * - If either map is read-only, the resulting map will also be read-only.
+ *
+ * @module
+ */
+
+import { Semigroup } from "@neotype/prelude/cmb.js";
+import { Eq } from "@neotype/prelude/cmp.js";
+
+declare global {
+    interface Map<K, V> {
+        [Eq.eq](that: Map<K, V>): boolean;
+
+        [Semigroup.cmb](that: Map<K, V>): Map<K, V>;
+    }
+
+    interface ReadonlyMap<K, V> {
+        [Eq.eq](that: ReadonlyMap<K, V>): boolean;
+
+        [Semigroup.cmb](that: ReadonlyMap<K, V>): ReadonlyMap<K, V>;
+    }
+}
+
+Map.prototype[Eq.eq] = function <K, V>(
+    this: Map<K, V>,
+    that: Map<K, V>,
+): boolean {
+    if (this.size !== that.size) {
+        return false;
+    }
+    for (const [kx, x] of this.entries()) {
+        if (!(that.has(kx) && that.get(kx) === x)) {
+            return false;
+        }
+    }
+    return true;
+};
+
+Map.prototype[Semigroup.cmb] = function <K, V>(
+    this: Map<K, V>,
+    that: Map<K, V>,
+): Map<K, V> {
+    return new Map(
+        (function* (self: Map<K, V>) {
+            yield* self;
+            yield* that;
+        })(this),
+    );
+};

--- a/src/set.ts
+++ b/src/set.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 Josh Martinez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Augmentations for the `Set` and `ReadonlySet` types.
+ *
+ * ## Importing this module
+ *
+ * This module's augmentations can be applied by using the following import:
+ *
+ * ```ts
+ * import "@neotype/instances/set.js";
+ * ```
+ *
+ * ## Comparing `Set` and `ReadonlySet`
+ *
+ * `Set` and `ReadonlySet` implement `Eq`.
+ *
+ * - Two sets are equal if they are the same size and contain the same values.
+ * - Values are compared using strict equality (`===`).
+ * - Read-only and non-read-only sets can be compared to each other.
+ *
+ * ## `Set` and `ReadonlySet` as semigroups
+ *
+ * `Set` and `ReadonlySet` implement `Semigroup`.
+ *
+ * - Sets are combined by taking their union.
+ * - Duplicate values are determined using strict equality (`===`).
+ * - Read-only and non-read-only sets can be combined with each other.
+ * - If either set is read-only, the resulting set will also be read-only.
+ *
+ * @module
+ */
+
+import { Semigroup } from "@neotype/prelude/cmb.js";
+import { Eq } from "@neotype/prelude/cmp.js";
+
+declare global {
+    interface Set<T> {
+        [Eq.eq](that: Set<T>): boolean;
+        [Semigroup.cmb](that: Set<T>): Set<T>;
+    }
+
+    interface ReadonlySet<T> {
+        [Eq.eq](that: ReadonlySet<T>): boolean;
+        [Semigroup.cmb](that: ReadonlySet<T>): ReadonlySet<T>;
+    }
+}
+
+Set.prototype[Eq.eq] = function <T>(this: Set<T>, that: Set<T>): boolean {
+    if (this.size !== that.size) {
+        return false;
+    }
+    for (const x of this.values()) {
+        if (!that.has(x)) {
+            return false;
+        }
+    }
+    return true;
+};
+
+Set.prototype[Semigroup.cmb] = function <T>(
+    this: Set<T>,
+    that: Set<T>,
+): Set<T> {
+    return new Set(
+        function* (this: Set<T>) {
+            yield* this;
+            yield* that;
+        }.call(this),
+    );
+};

--- a/test/array_test.ts
+++ b/test/array_test.ts
@@ -1,0 +1,120 @@
+import { cmb } from "@neotype/prelude/cmb.js";
+import { cmp, eq, icmp, ieq } from "@neotype/prelude/cmp.js";
+import { assert } from "chai";
+import * as fc from "fast-check";
+import "../src/array.js";
+import "../src/number.js";
+import "../src/string.js";
+
+describe("Array", () => {
+    specify("[Eq.eq]", () => {
+        fc.assert(
+            fc.property(
+                fc.array(fc.float({ noNaN: true })),
+                fc.array(fc.float({ noNaN: true })),
+                (xs, ys) => {
+                    const t0 = eq(xs, ys);
+                    assert.strictEqual(t0, ieq(xs, ys));
+
+                    const t1 = eq(xs as readonly number[], ys);
+                    assert.strictEqual(t1, ieq(xs, ys));
+
+                    const t2 = eq(xs, ys as readonly number[]);
+                    assert.strictEqual(t2, ieq(xs, ys));
+                },
+            ),
+        );
+    });
+
+    specify("[Ord.cmp]", () => {
+        fc.assert(
+            fc.property(
+                fc.array(fc.float({ noNaN: true })),
+                fc.array(fc.float({ noNaN: true })),
+                (xs, ys) => {
+                    const t0 = cmp(xs, ys);
+                    assert.strictEqual(t0, icmp(xs, ys));
+
+                    const t1 = cmp(xs as readonly number[], ys);
+                    assert.strictEqual(t1, icmp(xs, ys));
+
+                    const t2 = cmp(xs, ys as readonly number[]);
+                    assert.strictEqual(t2, icmp(xs, ys));
+                },
+            ),
+        );
+    });
+
+    specify("[Semigroup.cmb]", () => {
+        fc.assert(
+            fc.property(
+                fc.array(fc.float({ noNaN: true })),
+                fc.array(fc.float({ noNaN: true })),
+                (xs, ys) => {
+                    const t0 = cmb(xs, ys);
+                    assert.deepEqual(t0, [...xs, ...ys]);
+                },
+            ),
+        );
+    });
+});
+
+describe("tuple literal", () => {
+    specify("[Eq.eq]", () => {
+        fc.assert(
+            fc.property(
+                fc.float({ noNaN: true }),
+                fc.string(),
+                fc.float({ noNaN: true }),
+                fc.string(),
+                (a, x, b, y) => {
+                    const xs: [number, string] = [a, x];
+                    const ys: [number, string] = [b, y];
+                    const rxs = [a, x] as const;
+                    const rys = [b, y] as const;
+
+                    const t0 = eq(xs, ys);
+                    assert.strictEqual(t0, eq(a, b) && eq(x, y));
+
+                    const t1 = eq(xs, rys);
+                    assert.strictEqual(t1, eq(a, b) && eq(x, y));
+
+                    const t2 = eq(rxs, ys);
+                    assert.strictEqual(t2, eq(a, b) && eq(x, y));
+
+                    const t3 = eq(rxs, ys);
+                    assert.strictEqual(t3, eq(a, b) && eq(x, y));
+                },
+            ),
+        );
+    });
+
+    specify("[Ord.cmp]", () => {
+        fc.assert(
+            fc.property(
+                fc.float({ noNaN: true }),
+                fc.string(),
+                fc.float({ noNaN: true }),
+                fc.string(),
+                (a, x, b, y) => {
+                    const xs: [number, string] = [a, x];
+                    const ys: [number, string] = [b, y];
+                    const rxs = [a, x] as const;
+                    const rys = [b, y] as const;
+
+                    const t0 = cmp(xs, ys);
+                    assert.strictEqual(t0, cmb(cmp(a, b), cmp(x, y)));
+
+                    const t1 = cmp(xs, rys);
+                    assert.strictEqual(t1, cmb(cmp(a, b), cmp(x, y)));
+
+                    const t2 = cmp(rxs, ys);
+                    assert.strictEqual(t2, cmb(cmp(a, b), cmp(x, y)));
+
+                    const t3 = cmp(rxs, ys);
+                    assert.strictEqual(t3, cmb(cmp(a, b), cmp(x, y)));
+                },
+            ),
+        );
+    });
+});

--- a/test/map_test.ts
+++ b/test/map_test.ts
@@ -1,0 +1,187 @@
+import { cmb } from "@neotype/prelude/cmb.js";
+import { eq } from "@neotype/prelude/cmp.js";
+import { assert } from "chai";
+import "../src/map.js";
+
+describe("Map", () => {
+    specify("[Eq.eq]", () => {
+        const t0 = eq(
+            new Map([
+                ["a", 1],
+                ["b", 2],
+            ]),
+            new Map([
+                ["a", 1],
+                ["b", 2],
+            ]),
+        );
+        assert.strictEqual(t0, true);
+
+        const t1 = eq(
+            new Map([
+                ["a", 1],
+                ["b", 2],
+            ]),
+            new Map([
+                ["b", 2],
+                ["a", 1],
+            ]),
+        );
+        assert.strictEqual(t1, true);
+
+        const t2 = eq(
+            new Map([
+                ["a", 1],
+                ["b", 2],
+            ]),
+            new Map([
+                ["b", 2],
+                ["a", 1],
+                ["c", 3],
+            ]),
+        );
+        assert.strictEqual(t2, false);
+
+        const t3 = eq(
+            new Map([
+                ["a", 1],
+                ["b", 2],
+            ]),
+            new Map([
+                ["a", 1],
+                ["b", 3],
+            ]),
+        );
+        assert.strictEqual(t3, false);
+
+        const t4 = eq(
+            new Map([
+                ["a", 1],
+                ["b", 2],
+            ]),
+            new Map([
+                ["a", 1],
+                ["c", 2],
+            ]),
+        );
+        assert.strictEqual(t4, false);
+
+        const t5 = eq(
+            new Map([
+                ["a", 1],
+                ["b", 2],
+            ]) as ReadonlyMap<string, number>,
+            new Map([
+                ["a", 1],
+                ["b", 2],
+            ]),
+        );
+        assert.strictEqual(t5, true);
+
+        const t6 = eq(
+            new Map([
+                ["a", 1],
+                ["b", 2],
+            ]),
+            new Map([
+                ["b", 2],
+                ["a", 1],
+            ]) as ReadonlyMap<string, number>,
+        );
+        assert.strictEqual(t6, true);
+    });
+
+    specify("[Semigroup.cmb]", () => {
+        const t0 = cmb(
+            new Map([
+                ["a", 1],
+                ["b", 2],
+            ]),
+            new Map([
+                ["a", 1],
+                ["b", 2],
+            ]),
+        );
+        assert.deepEqual(
+            t0,
+            new Map([
+                ["a", 1],
+                ["b", 2],
+            ]),
+        );
+
+        const t1 = cmb(
+            new Map([
+                ["a", 1],
+                ["b", 2],
+            ]),
+            new Map([
+                ["a", 1],
+                ["b", 3],
+            ]),
+        );
+        assert.deepEqual(
+            t1,
+            new Map([
+                ["a", 1],
+                ["b", 3],
+            ]),
+        );
+
+        const t2 = cmb(
+            new Map([
+                ["a", 1],
+                ["b", 2],
+            ]),
+            new Map([
+                ["a", 1],
+                ["b", 2],
+                ["c", 3],
+            ]),
+        );
+        assert.deepEqual(
+            t2,
+            new Map([
+                ["a", 1],
+                ["b", 2],
+                ["c", 3],
+            ]),
+        );
+
+        const t3 = cmb(
+            new Map([
+                ["a", 1],
+                ["b", 2],
+            ]) as ReadonlyMap<string, number>,
+            new Map([
+                ["a", 1],
+                ["b", 2],
+            ]),
+        );
+        assert.deepEqual(
+            t3,
+            new Map([
+                ["a", 1],
+                ["b", 2],
+            ]),
+        );
+
+        const t4 = cmb(
+            new Map([
+                ["a", 1],
+                ["b", 2],
+            ]),
+            new Map([
+                ["a", 1],
+                ["b", 2],
+            ]) as ReadonlyMap<string, number>,
+        );
+        assert.deepEqual(
+            t4,
+            new Map([
+                ["a", 1],
+                ["b", 2],
+            ]),
+        );
+    });
+});

--- a/test/set_test.ts
+++ b/test/set_test.ts
@@ -1,0 +1,40 @@
+import { cmb } from "@neotype/prelude/cmb.js";
+import { eq } from "@neotype/prelude/cmp.js";
+import { assert } from "chai";
+import "../src/set.js";
+
+describe("Set", () => {
+    specify("[Eq.eq]", () => {
+        const t0 = eq(new Set([1, 2]), new Set([1, 2]));
+        assert.strictEqual(t0, true);
+
+        const t1 = eq(new Set([1, 2]), new Set([2, 1]));
+        assert.strictEqual(t1, true);
+
+        const t2 = eq(new Set([1, 2]), new Set([1, 2, 3]));
+        assert.strictEqual(t2, false);
+
+        const t3 = eq(new Set([1, 2]), new Set([1, 3]));
+        assert.strictEqual(t3, false);
+
+        const t4 = eq(new Set([1, 2]) as ReadonlySet<number>, new Set([1, 2]));
+        assert.strictEqual(t4, true);
+
+        const t5 = eq(new Set([1, 2]), new Set([1, 2]) as ReadonlySet<number>);
+        assert.strictEqual(t5, true);
+    });
+
+    specify("[Semigroup.cmb]", () => {
+        const t0 = cmb(new Set([1, 2]), new Set([1, 2]));
+        assert.deepEqual(t0, new Set([1, 2]));
+
+        const t1 = cmb(new Set([1, 2]), new Set([1, 2, 3]));
+        assert.deepEqual(t1, new Set([1, 2, 3]));
+
+        const t2 = cmb(new Set([1, 2]) as ReadonlySet<number>, new Set([1, 2]));
+        assert.deepEqual(t2, new Set([1, 2]));
+
+        const t3 = cmb(new Set([1, 2]), new Set([1, 2]) as ReadonlySet<number>);
+        assert.deepEqual(t3, new Set([1, 2]));
+    });
+});


### PR DESCRIPTION
This introduces:

- `Eq`, `Ord`, and `Semigroup` instances for `Array` and `ReadonlyArray`
- `Eq` and `Ord` instances for tuple literals and read-only tuple literals
- `Eq` and `Semigroup` instances for `Set` and `ReadonlySet`
- `Eq` and `Semigroup` instances for `Map` and `ReadonlyMap`