### PR TITLE
Introduce modules for typed arrays

### DIFF
--- a/src/bigint64_array.ts
+++ b/src/bigint64_array.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 Josh Martinez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Augmentations for the `BigInt64Array` type.
+ *
+ * ## Importing this module
+ *
+ * This module's augmentations can be applied by using the following import:
+ *
+ * ```ts
+ * import "@neotype/instances/bigint64_array.js";
+ * ```
+ *
+ * ## Comparing `BigInt64Array`
+ *
+ * `BigInt64Array` implements `Eq` and `Ord`.
+ *
+ * - Two BigInt64Arrays are equal when they are the same length and their
+ *   elements are strictly equal using `===`.
+ * - BigInt64Arrays are ordered lexicographically, and their elements are
+ *   ordered from least to greatest.
+ *
+ * ## `BigInt64Array` as a semigroup
+ *
+ * `BigInt64Array` implements `Semigroup`. BigInt64Arrays are combined using
+ * concatenation. The combination will allocate memory equivalent to the sum of
+ * the combined arrays' sizes.
+ *
+ * @module
+ */
+
+import { Semigroup } from "@neotype/prelude/cmb.js";
+import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+
+declare global {
+    interface BigInt64Array {
+        [Eq.eq](that: BigInt64Array): boolean;
+
+        [Ord.cmp](that: BigInt64Array): Ordering;
+
+        [Semigroup.cmb](that: BigInt64Array): BigInt64Array;
+    }
+}
+
+BigInt64Array.prototype[Eq.eq] = function (that: BigInt64Array): boolean {
+    return ieqBy(this, that, (x, y) => x === y);
+};
+
+BigInt64Array.prototype[Ord.cmp] = function (that: BigInt64Array): Ordering {
+    return icmpBy(this, that, (x, y) => {
+        const n = x - y;
+        if (n < 0) {
+            return Ordering.less;
+        }
+        if (n > 0) {
+            return Ordering.greater;
+        }
+        return Ordering.equal;
+    });
+};
+
+BigInt64Array.prototype[Semigroup.cmb] = function (
+    that: BigInt64Array,
+): BigInt64Array {
+    const result = new BigInt64Array(this.length + that.length);
+    result.set(this);
+    result.set(that, this.length);
+    return result;
+};

--- a/src/biguint64_array.ts
+++ b/src/biguint64_array.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 Josh Martinez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Augmentations for the `BigUint64Array` type.
+ *
+ * ## Importing this module
+ *
+ * This module's augmentations can be applied by using the following import:
+ *
+ * ```ts
+ * import "@neotype/instances/biguint64_array.js";
+ * ```
+ *
+ * ## Comparing `BigUint64Array`
+ *
+ * `BigUint64Array` implements `Eq` and `Ord`.
+ *
+ * - Two BigUint64Arrays are equal when they are the same length and their
+ *   elements are strictly equal using `===`.
+ * - BigUint64Arrays are ordered lexicographically, and their elements are
+ *   ordered from least to greatest.
+ *
+ * ## `BigUint64Array` as a semigroup
+ *
+ * `BigUint64Array` implements `Semigroup`. BigUint64Arrays are combined using
+ * concatenation. The combination will allocate memory equivalent to the sum of
+ * the combined arrays' sizes.
+ *
+ * @module
+ */
+
+import { Semigroup } from "@neotype/prelude/cmb.js";
+import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+
+declare global {
+    interface BigUint64Array {
+        [Eq.eq](that: BigUint64Array): boolean;
+
+        [Ord.cmp](that: BigUint64Array): Ordering;
+
+        [Semigroup.cmb](that: BigUint64Array): BigUint64Array;
+    }
+}
+
+BigUint64Array.prototype[Eq.eq] = function (that: BigUint64Array): boolean {
+    return ieqBy(this, that, (x, y) => x === y);
+};
+
+BigUint64Array.prototype[Ord.cmp] = function (that: BigUint64Array): Ordering {
+    return icmpBy(this, that, (x, y) => {
+        const n = x - y;
+        if (n < 0) {
+            return Ordering.less;
+        }
+        if (n > 0) {
+            return Ordering.greater;
+        }
+        return Ordering.equal;
+    });
+};
+
+BigUint64Array.prototype[Semigroup.cmb] = function (
+    that: BigUint64Array,
+): BigUint64Array {
+    const result = new BigUint64Array(this.length + that.length);
+    result.set(this);
+    result.set(that, this.length);
+    return result;
+};

--- a/src/float32_array.ts
+++ b/src/float32_array.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 Josh Martinez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Augmentations for the `Float32Array` type.
+ *
+ * ## Importing this module
+ *
+ * This module's augmentations can be applied by using the following import:
+ *
+ * ```ts
+ * import "@neotype/instances/float32_array.js";
+ * ```
+ *
+ * ## Comparing `Float32Array`
+ *
+ * `Float32Array` implements `Eq` and `Ord`.
+ *
+ * - Two Float32Arrays are equal when they are the same length and their
+ *   elements are strictly equal using `===`.
+ * - Float32Arrays are ordered lexicographically, and their elements are ordered
+ *   from least to greatest.
+ *
+ * ## `Float32Array` as a semigroup
+ *
+ * `Float32Array` implements `Semigroup`. Float32Arrays are combined using
+ * concatenation. The combination will allocate memory equivalent to the sum of
+ * the combined arrays' sizes.
+ *
+ * @module
+ */
+
+import { Semigroup } from "@neotype/prelude/cmb.js";
+import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+
+declare global {
+    interface Float32Array {
+        [Eq.eq](that: Float32Array): boolean;
+
+        [Ord.cmp](that: Float32Array): Ordering;
+
+        [Semigroup.cmb](that: Float32Array): Float32Array;
+    }
+}
+
+Float32Array.prototype[Eq.eq] = function (that: Float32Array): boolean {
+    return ieqBy(this, that, (x, y) => x === y);
+};
+
+Float32Array.prototype[Ord.cmp] = function (that: Float32Array): Ordering {
+    return icmpBy(this, that, (x, y) => Ordering.fromNumber(x - y));
+};
+
+Float32Array.prototype[Semigroup.cmb] = function (
+    that: Float32Array,
+): Float32Array {
+    const result = new Float32Array(this.length + that.length);
+    result.set(this);
+    result.set(that, this.length);
+    return result;
+};

--- a/src/float64_array.ts
+++ b/src/float64_array.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 Josh Martinez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Augmentations for the `Float64Array` type.
+ *
+ * ## Importing this module
+ *
+ * This module's augmentations can be applied by using the following import:
+ *
+ * ```ts
+ * import "@neotype/instances/float64_array.js";
+ * ```
+ *
+ * ## Comparing `Float64Array`
+ *
+ * `Float64Array` implements `Eq` and `Ord`.
+ *
+ * - Two Float64Arrays are equal when they are the same length and their
+ *   elements are strictly equal using `===`.
+ * - Float64Arrays are ordered lexicographically, and their elements are ordered
+ *   from least to greatest.
+ *
+ * ## `Float64Array` as a semigroup
+ *
+ * `Float64Array` implements `Semigroup`. Float64Arrays are combined using
+ * concatenation. The combination will allocate memory equivalent to the sum of
+ * the combined arrays' sizes.
+ *
+ * @module
+ */
+
+import { Semigroup } from "@neotype/prelude/cmb.js";
+import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+
+declare global {
+    interface Float64Array {
+        [Eq.eq](that: Float64Array): boolean;
+
+        [Ord.cmp](that: Float64Array): Ordering;
+
+        [Semigroup.cmb](that: Float64Array): Float64Array;
+    }
+}
+
+Float64Array.prototype[Eq.eq] = function (that: Float64Array): boolean {
+    return ieqBy(this, that, (x, y) => x === y);
+};
+
+Float64Array.prototype[Ord.cmp] = function (that: Float64Array): Ordering {
+    return icmpBy(this, that, (x, y) => Ordering.fromNumber(x - y));
+};
+
+Float64Array.prototype[Semigroup.cmb] = function (
+    that: Float64Array,
+): Float64Array {
+    const result = new Float64Array(this.length + that.length);
+    result.set(this);
+    result.set(that, this.length);
+    return result;
+};

--- a/src/int16_array.ts
+++ b/src/int16_array.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 Josh Martinez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Augmentations for the `Int16Array` type.
+ *
+ * ## Importing this module
+ *
+ * This module's augmentations can be applied by using the following import:
+ *
+ * ```ts
+ * import "@neotype/instances/int16_array.js";
+ * ```
+ *
+ * ## Comparing `Int16Array`
+ *
+ * `Int16Array` implements `Eq` and `Ord`.
+ *
+ * - Two Int16Arrays are equal when they are the same length and their elements
+ *   are strictly equal using `===`.
+ * - Int16Arrays are ordered lexicographically, and their elements are ordered
+ *   from least to greatest.
+ *
+ * ## `Int16Array` as a semigroup
+ *
+ * `Int16Array` implements `Semigroup`. Int16Arrays are combined using
+ * concatenation. The combination will allocate memory equivalent to the sum of
+ * the combined arrays' sizes.
+ *
+ * @module
+ */
+
+import { Semigroup } from "@neotype/prelude/cmb.js";
+import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+
+declare global {
+    interface Int16Array {
+        [Eq.eq](that: Int16Array): boolean;
+
+        [Ord.cmp](that: Int16Array): Ordering;
+
+        [Semigroup.cmb](that: Int16Array): Int16Array;
+    }
+}
+
+Int16Array.prototype[Eq.eq] = function (that: Int16Array): boolean {
+    return ieqBy(this, that, (x, y) => x === y);
+};
+
+Int16Array.prototype[Ord.cmp] = function (that: Int16Array): Ordering {
+    return icmpBy(this, that, (x, y) => Ordering.fromNumber(x - y));
+};
+
+Int16Array.prototype[Semigroup.cmb] = function (that: Int16Array): Int16Array {
+    const result = new Int16Array(this.length + that.length);
+    result.set(this);
+    result.set(that, this.length);
+    return result;
+};

--- a/src/int32_array.ts
+++ b/src/int32_array.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 Josh Martinez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Augmentations for the `Int32Array` type.
+ *
+ * ## Importing this module
+ *
+ * This module's augmentations can be applied by using the following import:
+ *
+ * ```ts
+ * import "@neotype/instances/int32_array.js";
+ * ```
+ *
+ * ## Comparing `Int32Array`
+ *
+ * `Int32Array` implements `Eq` and `Ord`.
+ *
+ * - Two Int32Arrays are equal when they are the same length and their elements
+ *   are strictly equal using `===`.
+ * - Int32Arrays are ordered lexicographically, and their elements are ordered
+ *   from least to greatest.
+ *
+ * ## `Int32Array` as a semigroup
+ *
+ * `Int32Array` implements `Semigroup`. Int32Arrays are combined using
+ * concatenation. The combination will allocate memory equivalent to the sum of
+ * the combined arrays' sizes.
+ *
+ * @module
+ */
+
+import { Semigroup } from "@neotype/prelude/cmb.js";
+import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+
+declare global {
+    interface Int32Array {
+        [Eq.eq](that: Int32Array): boolean;
+
+        [Ord.cmp](that: Int32Array): Ordering;
+
+        [Semigroup.cmb](that: Int32Array): Int32Array;
+    }
+}
+
+Int32Array.prototype[Eq.eq] = function (that: Int32Array): boolean {
+    return ieqBy(this, that, (x, y) => x === y);
+};
+
+Int32Array.prototype[Ord.cmp] = function (that: Int32Array): Ordering {
+    return icmpBy(this, that, (x, y) => Ordering.fromNumber(x - y));
+};
+
+Int32Array.prototype[Semigroup.cmb] = function (that: Int32Array): Int32Array {
+    const result = new Int32Array(this.length + that.length);
+    result.set(this);
+    result.set(that, this.length);
+    return result;
+};

--- a/src/int8_array.ts
+++ b/src/int8_array.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 Josh Martinez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Augmentations for the `Int8Array` type.
+ *
+ * ## Importing this module
+ *
+ * This module's augmentations can be applied by using the following import:
+ *
+ * ```ts
+ * import "@neotype/instances/int8_array.js";
+ * ```
+ *
+ * ## Comparing `Int8Array`
+ *
+ * `Int8Array` implements `Eq` and `Ord`.
+ *
+ * - Two Int8Arrays are equal when they are the same length and their elements
+ *   are strictly equal using `===`.
+ * - Int8Arrays are ordered lexicographically, and their elements are ordered
+ *   from least to greatest.
+ *
+ * ## `Int8Array` as a semigroup
+ *
+ * `Int8Array` implements `Semigroup`. Int8Arrays are combined using
+ * concatenation. The combination will allocate memory equivalent to the sum of
+ * the combined arrays' sizes.
+ *
+ * @module
+ */
+
+import { Semigroup } from "@neotype/prelude/cmb.js";
+import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+
+declare global {
+    interface Int8Array {
+        [Eq.eq](that: Int8Array): boolean;
+
+        [Ord.cmp](that: Int8Array): Ordering;
+
+        [Semigroup.cmb](that: Int8Array): Int8Array;
+    }
+}
+
+Int8Array.prototype[Eq.eq] = function (that: Int8Array): boolean {
+    return ieqBy(this, that, (x, y) => x === y);
+};
+
+Int8Array.prototype[Ord.cmp] = function (that: Int8Array): Ordering {
+    return icmpBy(this, that, (x, y) => Ordering.fromNumber(x - y));
+};
+
+Int8Array.prototype[Semigroup.cmb] = function (that: Int8Array): Int8Array {
+    const result = new Int8Array(this.length + that.length);
+    result.set(this);
+    result.set(that, this.length);
+    return result;
+};

--- a/src/uint16_array.ts
+++ b/src/uint16_array.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 Josh Martinez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Augmentations for the `Uint16Array` type.
+ *
+ * ## Importing this module
+ *
+ * This module's augmentations can be applied by using the following import:
+ *
+ * ```ts
+ * import "@neotype/instances/uint16_array.js";
+ * ```
+ *
+ * ## Comparing `Uint16Array`
+ *
+ * `Uint16Array` implements `Eq` and `Ord`.
+ *
+ * - Two Uint16Arrays are equal when they are the same length and their elements
+ *   are strictly equal using `===`.
+ * - Uint16Arrays are ordered lexicographically, and their elements are ordered
+ *   from least to greatest.
+ *
+ * ## `Uint16Array` as a semigroup
+ *
+ * `Uint16Array` implements `Semigroup`. Uint16Arrays are combined using
+ * concatenation. The combination will allocate memory equivalent to the sum of
+ * the combined arrays' sizes.
+ *
+ * @module
+ */
+
+import { Semigroup } from "@neotype/prelude/cmb.js";
+import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+
+declare global {
+    interface Uint16Array {
+        [Eq.eq](that: Uint16Array): boolean;
+
+        [Ord.cmp](that: Uint16Array): Ordering;
+
+        [Semigroup.cmb](that: Uint16Array): Uint16Array;
+    }
+}
+
+Uint16Array.prototype[Eq.eq] = function (that: Uint16Array): boolean {
+    return ieqBy(this, that, (x, y) => x === y);
+};
+
+Uint16Array.prototype[Ord.cmp] = function (that: Uint16Array): Ordering {
+    return icmpBy(this, that, (x, y) => Ordering.fromNumber(x - y));
+};
+
+Uint16Array.prototype[Semigroup.cmb] = function (
+    that: Uint16Array,
+): Uint16Array {
+    const result = new Uint16Array(this.length + that.length);
+    result.set(this);
+    result.set(that, this.length);
+    return result;
+};

--- a/src/uint32_array.ts
+++ b/src/uint32_array.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 Josh Martinez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Augmentations for the `Uint32Array` type.
+ *
+ * ## Importing this module
+ *
+ * This module's augmentations can be applied by using the following import:
+ *
+ * ```ts
+ * import "@neotype/instances/uint32_array.js";
+ * ```
+ *
+ * ## Comparing `Uint32Array`
+ *
+ * `Uint32Array` implements `Eq` and `Ord`.
+ *
+ * - Two Uint32Arrays are equal when they are the same length and their elements
+ *   are strictly equal using `===`.
+ * - Uint32Arrays are ordered lexicographically, and their elements are ordered
+ *   from least to greatest.
+ *
+ * ## `Uint32Array` as a semigroup
+ *
+ * `Uint32Array` implements `Semigroup`. Uint32Arrays are combined using
+ * concatenation. The combination will allocate memory equivalent to the sum of
+ * the combined arrays' sizes.
+ *
+ * @module
+ */
+
+import { Semigroup } from "@neotype/prelude/cmb.js";
+import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+
+declare global {
+    interface Uint32Array {
+        [Eq.eq](that: Uint32Array): boolean;
+
+        [Ord.cmp](that: Uint32Array): Ordering;
+
+        [Semigroup.cmb](that: Uint32Array): Uint32Array;
+    }
+}
+
+Uint32Array.prototype[Eq.eq] = function (that: Uint32Array): boolean {
+    return ieqBy(this, that, (x, y) => x === y);
+};
+
+Uint32Array.prototype[Ord.cmp] = function (that: Uint32Array): Ordering {
+    return icmpBy(this, that, (x, y) => Ordering.fromNumber(x - y));
+};
+
+Uint32Array.prototype[Semigroup.cmb] = function (
+    that: Uint32Array,
+): Uint32Array {
+    const result = new Uint32Array(this.length + that.length);
+    result.set(this);
+    result.set(that, this.length);
+    return result;
+};

--- a/src/uint8_array.ts
+++ b/src/uint8_array.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 Josh Martinez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Augmentations for the `Uint8Array` type.
+ *
+ * ## Importing this module
+ *
+ * This module's augmentations can be applied by using the following import:
+ *
+ * ```ts
+ * import "@neotype/instances/uint8_array.js";
+ * ```
+ *
+ * ## Comparing `Uint8Array`
+ *
+ * `Uint8Array` implements `Eq` and `Ord`.
+ *
+ * - Two Uint8Arrays are equal when they are the same length and their elements
+ *   are strictly equal using `===`.
+ * - Uint8Arrays are ordered lexicographically, and their elements are ordered
+ *   from least to greatest.
+ *
+ * ## `Uint8Array` as a semigroup
+ *
+ * `Uint8Array` implements `Semigroup`. Uint8Arrays are combined using
+ * concatenation. The combination will allocate memory equivalent to the sum of
+ * the combined arrays' sizes.
+ *
+ * @module
+ */
+
+import { Semigroup } from "@neotype/prelude/cmb.js";
+import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+
+declare global {
+    interface Uint8Array {
+        [Eq.eq](that: Uint8Array): boolean;
+
+        [Ord.cmp](that: Uint8Array): Ordering;
+
+        [Semigroup.cmb](that: Uint8Array): Uint8Array;
+    }
+}
+
+Uint8Array.prototype[Eq.eq] = function (that: Uint8Array): boolean {
+    return ieqBy(this, that, (x, y) => x === y);
+};
+
+Uint8Array.prototype[Ord.cmp] = function (that: Uint8Array): Ordering {
+    return icmpBy(this, that, (x, y) => Ordering.fromNumber(x - y));
+};
+
+Uint8Array.prototype[Semigroup.cmb] = function (that: Uint8Array): Uint8Array {
+    const result = new Uint8Array(this.length + that.length);
+    result.set(this);
+    result.set(that, this.length);
+    return result;
+};

--- a/src/uint8_clamped_array.ts
+++ b/src/uint8_clamped_array.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 Josh Martinez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Augmentations for the `Uint8ClampedArray` type.
+ *
+ * ## Importing this module
+ *
+ * This module's augmentations can be applied by using the following import:
+ *
+ * ```ts
+ * import "@neotype/instances/uint8_clamped_array.js";
+ * ```
+ *
+ * ## Comparing `Uint8ClampedArray`
+ *
+ * `Uint8ClampedArray` implements `Eq` and `Ord`.
+ *
+ * - Two Uint8ClampedArrays are equal when they are the same length and their
+ *   elements are strictly equal using `===`.
+ * - Uint8ClampedArrays are ordered lexicographically, and their elements are
+ *   ordered from least to greatest.
+ *
+ * ## `Uint8ClampedArray` as a semigroup
+ *
+ * `Uint8ClampedArray` implements `Semigroup`. Uint8ClampedArrays are combined
+ * using concatenation. The combination will allocate memory equivalent to the
+ * sum of the combined arrays' sizes.
+ *
+ * @module
+ */
+
+import { Semigroup } from "@neotype/prelude/cmb.js";
+import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+
+declare global {
+    interface Uint8ClampedArray {
+        [Eq.eq](that: Uint8ClampedArray): boolean;
+
+        [Ord.cmp](that: Uint8ClampedArray): Ordering;
+
+        [Semigroup.cmb](that: Uint8ClampedArray): Uint8ClampedArray;
+    }
+}
+
+Uint8ClampedArray.prototype[Eq.eq] = function (
+    that: Uint8ClampedArray,
+): boolean {
+    return ieqBy(this, that, (x, y) => x === y);
+};
+
+Uint8ClampedArray.prototype[Ord.cmp] = function (
+    that: Uint8ClampedArray,
+): Ordering {
+    return icmpBy(this, that, (x, y) => Ordering.fromNumber(x - y));
+};
+
+Uint8ClampedArray.prototype[Semigroup.cmb] = function (
+    that: Uint8ClampedArray,
+): Uint8ClampedArray {
+    const result = new Uint8ClampedArray(this.length + that.length);
+    result.set(this);
+    result.set(that, this.length);
+    return result;
+};

--- a/test/bigint64_array_test.ts
+++ b/test/bigint64_array_test.ts
@@ -1,0 +1,50 @@
+import { cmb } from "@neotype/prelude/cmb.js";
+import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { assert } from "chai";
+import * as fc from "fast-check";
+import "../src/bigint64_array.js";
+
+describe("BigInt64Array", () => {
+    specify("[Eq.eq]", () => {
+        fc.assert(
+            fc.property(fc.bigInt64Array(), fc.bigInt64Array(), (xs, ys) => {
+                const t0 = eq(xs, ys);
+                assert.strictEqual(
+                    t0,
+                    ieqBy(xs, ys, (x, y) => x === y),
+                );
+            }),
+        );
+    });
+
+    specify("[Ord.cmp]", () => {
+        fc.assert(
+            fc.property(fc.bigInt64Array(), fc.bigInt64Array(), (xs, ys) => {
+                const t0 = cmp(xs, ys);
+                assert.strictEqual(
+                    t0,
+                    icmpBy(xs, ys, (x, y) =>
+                        x < y
+                            ? Ordering.less
+                            : x > y
+                            ? Ordering.greater
+                            : Ordering.equal,
+                    ),
+                );
+            }),
+        );
+    });
+
+    specify("[Semigroup.cmb]", () => {
+        fc.assert(
+            fc.property(fc.bigInt64Array(), fc.bigInt64Array(), (xs, ys) => {
+                const t0 = cmb(xs, ys);
+                const exp = new BigInt64Array(xs.length + ys.length);
+                exp.set(xs);
+                exp.set(ys, xs.length);
+                assert.deepEqual(t0, exp);
+                assert.strictEqual(exp.length, xs.length + ys.length);
+            }),
+        );
+    });
+});

--- a/test/biguint64_array_test.ts
+++ b/test/biguint64_array_test.ts
@@ -1,0 +1,50 @@
+import { cmb } from "@neotype/prelude/cmb.js";
+import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { assert } from "chai";
+import * as fc from "fast-check";
+import "../src/biguint64_array.js";
+
+describe("BigUint64Array", () => {
+    specify("[Eq.eq]", () => {
+        fc.assert(
+            fc.property(fc.bigUint64Array(), fc.bigUint64Array(), (xs, ys) => {
+                const t0 = eq(xs, ys);
+                assert.strictEqual(
+                    t0,
+                    ieqBy(xs, ys, (x, y) => x === y),
+                );
+            }),
+        );
+    });
+
+    specify("[Ord.cmp]", () => {
+        fc.assert(
+            fc.property(fc.bigUint64Array(), fc.bigUint64Array(), (xs, ys) => {
+                const t0 = cmp(xs, ys);
+                assert.strictEqual(
+                    t0,
+                    icmpBy(xs, ys, (x, y) =>
+                        x < y
+                            ? Ordering.less
+                            : x > y
+                            ? Ordering.greater
+                            : Ordering.equal,
+                    ),
+                );
+            }),
+        );
+    });
+
+    specify("[Semigroup.cmb]", () => {
+        fc.assert(
+            fc.property(fc.bigUint64Array(), fc.bigUint64Array(), (xs, ys) => {
+                const t0 = cmb(xs, ys);
+                const exp = new BigUint64Array(xs.length + ys.length);
+                exp.set(xs);
+                exp.set(ys, xs.length);
+                assert.deepEqual(t0, exp);
+                assert.strictEqual(exp.length, xs.length + ys.length);
+            }),
+        );
+    });
+});

--- a/test/float32_array_test.ts
+++ b/test/float32_array_test.ts
@@ -1,0 +1,44 @@
+import { cmb } from "@neotype/prelude/cmb.js";
+import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { assert } from "chai";
+import * as fc from "fast-check";
+import "../src/float32_array.js";
+
+describe("Float32Array", () => {
+    specify("[Eq.eq]", () => {
+        fc.assert(
+            fc.property(fc.float32Array(), fc.float32Array(), (xs, ys) => {
+                const t0 = eq(xs, ys);
+                assert.strictEqual(
+                    t0,
+                    ieqBy(xs, ys, (x, y) => x === y),
+                );
+            }),
+        );
+    });
+
+    specify("[Ord.cmp]", () => {
+        fc.assert(
+            fc.property(fc.float32Array(), fc.float32Array(), (xs, ys) => {
+                const t0 = cmp(xs, ys);
+                assert.strictEqual(
+                    t0,
+                    icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+                );
+            }),
+        );
+    });
+
+    specify("[Semigroup.cmb]", () => {
+        fc.assert(
+            fc.property(fc.float32Array(), fc.float32Array(), (xs, ys) => {
+                const t0 = cmb(xs, ys);
+                const exp = new Float32Array(xs.length + ys.length);
+                exp.set(xs);
+                exp.set(ys, xs.length);
+                assert.deepEqual(t0, exp);
+                assert.strictEqual(exp.length, xs.length + ys.length);
+            }),
+        );
+    });
+});

--- a/test/float64_array_test.ts
+++ b/test/float64_array_test.ts
@@ -1,0 +1,44 @@
+import { cmb } from "@neotype/prelude/cmb.js";
+import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { assert } from "chai";
+import * as fc from "fast-check";
+import "../src/float64_array.js";
+
+describe("Float64Array", () => {
+    specify("[Eq.eq]", () => {
+        fc.assert(
+            fc.property(fc.float64Array(), fc.float64Array(), (xs, ys) => {
+                const t0 = eq(xs, ys);
+                assert.strictEqual(
+                    t0,
+                    ieqBy(xs, ys, (x, y) => x === y),
+                );
+            }),
+        );
+    });
+
+    specify("[Ord.cmp]", () => {
+        fc.assert(
+            fc.property(fc.float64Array(), fc.float64Array(), (xs, ys) => {
+                const t0 = cmp(xs, ys);
+                assert.strictEqual(
+                    t0,
+                    icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+                );
+            }),
+        );
+    });
+
+    specify("[Semigroup.cmb]", () => {
+        fc.assert(
+            fc.property(fc.float64Array(), fc.float64Array(), (xs, ys) => {
+                const t0 = cmb(xs, ys);
+                const exp = new Float64Array(xs.length + ys.length);
+                exp.set(xs);
+                exp.set(ys, xs.length);
+                assert.deepEqual(t0, exp);
+                assert.strictEqual(exp.length, xs.length + ys.length);
+            }),
+        );
+    });
+});

--- a/test/int16_array_test.ts
+++ b/test/int16_array_test.ts
@@ -1,0 +1,44 @@
+import { cmb } from "@neotype/prelude/cmb.js";
+import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { assert } from "chai";
+import * as fc from "fast-check";
+import "../src/int16_array.js";
+
+describe("Int16Array", () => {
+    specify("[Eq.eq]", () => {
+        fc.assert(
+            fc.property(fc.int16Array(), fc.int16Array(), (xs, ys) => {
+                const t0 = eq(xs, ys);
+                assert.strictEqual(
+                    t0,
+                    ieqBy(xs, ys, (x, y) => x === y),
+                );
+            }),
+        );
+    });
+
+    specify("[Ord.cmp]", () => {
+        fc.assert(
+            fc.property(fc.int16Array(), fc.int16Array(), (xs, ys) => {
+                const t0 = cmp(xs, ys);
+                assert.strictEqual(
+                    t0,
+                    icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+                );
+            }),
+        );
+    });
+
+    specify("[Semigroup.cmb]", () => {
+        fc.assert(
+            fc.property(fc.int16Array(), fc.int16Array(), (xs, ys) => {
+                const t0 = cmb(xs, ys);
+                const exp = new Int16Array(xs.length + ys.length);
+                exp.set(xs);
+                exp.set(ys, xs.length);
+                assert.deepEqual(t0, exp);
+                assert.strictEqual(exp.length, xs.length + ys.length);
+            }),
+        );
+    });
+});

--- a/test/int32_array_test.ts
+++ b/test/int32_array_test.ts
@@ -1,0 +1,44 @@
+import { cmb } from "@neotype/prelude/cmb.js";
+import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { assert } from "chai";
+import * as fc from "fast-check";
+import "../src/int32_array.js";
+
+describe("Int32Array", () => {
+    specify("[Eq.eq]", () => {
+        fc.assert(
+            fc.property(fc.int32Array(), fc.int32Array(), (xs, ys) => {
+                const t0 = eq(xs, ys);
+                assert.strictEqual(
+                    t0,
+                    ieqBy(xs, ys, (x, y) => x === y),
+                );
+            }),
+        );
+    });
+
+    specify("[Ord.cmp]", () => {
+        fc.assert(
+            fc.property(fc.int32Array(), fc.int32Array(), (xs, ys) => {
+                const t0 = cmp(xs, ys);
+                assert.strictEqual(
+                    t0,
+                    icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+                );
+            }),
+        );
+    });
+
+    specify("[Semigroup.cmb]", () => {
+        fc.assert(
+            fc.property(fc.int32Array(), fc.int32Array(), (xs, ys) => {
+                const t0 = cmb(xs, ys);
+                const exp = new Int32Array(xs.length + ys.length);
+                exp.set(xs);
+                exp.set(ys, xs.length);
+                assert.deepEqual(t0, exp);
+                assert.strictEqual(exp.length, xs.length + ys.length);
+            }),
+        );
+    });
+});

--- a/test/int8_array_test.ts
+++ b/test/int8_array_test.ts
@@ -1,0 +1,44 @@
+import { cmb } from "@neotype/prelude/cmb.js";
+import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { assert } from "chai";
+import * as fc from "fast-check";
+import "../src/int8_array.js";
+
+describe("Int8Array", () => {
+    specify("[Eq.eq]", () => {
+        fc.assert(
+            fc.property(fc.int8Array(), fc.int8Array(), (xs, ys) => {
+                const t0 = eq(xs, ys);
+                assert.strictEqual(
+                    t0,
+                    ieqBy(xs, ys, (x, y) => x === y),
+                );
+            }),
+        );
+    });
+
+    specify("[Ord.cmp]", () => {
+        fc.assert(
+            fc.property(fc.int8Array(), fc.int8Array(), (xs, ys) => {
+                const t0 = cmp(xs, ys);
+                assert.strictEqual(
+                    t0,
+                    icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+                );
+            }),
+        );
+    });
+
+    specify("[Semigroup.cmb]", () => {
+        fc.assert(
+            fc.property(fc.int8Array(), fc.int8Array(), (xs, ys) => {
+                const t0 = cmb(xs, ys);
+                const exp = new Int8Array(xs.length + ys.length);
+                exp.set(xs);
+                exp.set(ys, xs.length);
+                assert.deepEqual(t0, exp);
+                assert.strictEqual(exp.length, xs.length + ys.length);
+            }),
+        );
+    });
+});

--- a/test/uint16_array_test.ts
+++ b/test/uint16_array_test.ts
@@ -1,0 +1,44 @@
+import { cmb } from "@neotype/prelude/cmb.js";
+import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { assert } from "chai";
+import * as fc from "fast-check";
+import "../src/uint16_array.js";
+
+describe("Uint16Array", () => {
+    specify("[Eq.eq]", () => {
+        fc.assert(
+            fc.property(fc.uint16Array(), fc.uint16Array(), (xs, ys) => {
+                const t0 = eq(xs, ys);
+                assert.strictEqual(
+                    t0,
+                    ieqBy(xs, ys, (x, y) => x === y),
+                );
+            }),
+        );
+    });
+
+    specify("[Ord.cmp]", () => {
+        fc.assert(
+            fc.property(fc.uint16Array(), fc.uint16Array(), (xs, ys) => {
+                const t0 = cmp(xs, ys);
+                assert.strictEqual(
+                    t0,
+                    icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+                );
+            }),
+        );
+    });
+
+    specify("[Semigroup.cmb]", () => {
+        fc.assert(
+            fc.property(fc.uint16Array(), fc.uint16Array(), (xs, ys) => {
+                const t0 = cmb(xs, ys);
+                const exp = new Uint16Array(xs.length + ys.length);
+                exp.set(xs);
+                exp.set(ys, xs.length);
+                assert.deepEqual(t0, exp);
+                assert.strictEqual(exp.length, xs.length + ys.length);
+            }),
+        );
+    });
+});

--- a/test/uint32_array_test.ts
+++ b/test/uint32_array_test.ts
@@ -1,0 +1,44 @@
+import { cmb } from "@neotype/prelude/cmb.js";
+import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { assert } from "chai";
+import * as fc from "fast-check";
+import "../src/uint32_array.js";
+
+describe("Uint32Array", () => {
+    specify("[Eq.eq]", () => {
+        fc.assert(
+            fc.property(fc.uint32Array(), fc.uint32Array(), (xs, ys) => {
+                const t0 = eq(xs, ys);
+                assert.strictEqual(
+                    t0,
+                    ieqBy(xs, ys, (x, y) => x === y),
+                );
+            }),
+        );
+    });
+
+    specify("[Ord.cmp]", () => {
+        fc.assert(
+            fc.property(fc.uint32Array(), fc.uint32Array(), (xs, ys) => {
+                const t0 = cmp(xs, ys);
+                assert.strictEqual(
+                    t0,
+                    icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+                );
+            }),
+        );
+    });
+
+    specify("[Semigroup.cmb]", () => {
+        fc.assert(
+            fc.property(fc.uint32Array(), fc.uint32Array(), (xs, ys) => {
+                const t0 = cmb(xs, ys);
+                const exp = new Uint32Array(xs.length + ys.length);
+                exp.set(xs);
+                exp.set(ys, xs.length);
+                assert.deepEqual(t0, exp);
+                assert.strictEqual(exp.length, xs.length + ys.length);
+            }),
+        );
+    });
+});

--- a/test/uint8_array_test.ts
+++ b/test/uint8_array_test.ts
@@ -1,0 +1,44 @@
+import { cmb } from "@neotype/prelude/cmb.js";
+import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { assert } from "chai";
+import * as fc from "fast-check";
+import "../src/uint8_array.js";
+
+describe("Uint8Array", () => {
+    specify("[Eq.eq]", () => {
+        fc.assert(
+            fc.property(fc.uint8Array(), fc.uint8Array(), (xs, ys) => {
+                const t0 = eq(xs, ys);
+                assert.strictEqual(
+                    t0,
+                    ieqBy(xs, ys, (x, y) => x === y),
+                );
+            }),
+        );
+    });
+
+    specify("[Ord.cmp]", () => {
+        fc.assert(
+            fc.property(fc.uint8Array(), fc.uint8Array(), (xs, ys) => {
+                const t0 = cmp(xs, ys);
+                assert.strictEqual(
+                    t0,
+                    icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+                );
+            }),
+        );
+    });
+
+    specify("[Semigroup.cmb]", () => {
+        fc.assert(
+            fc.property(fc.uint8Array(), fc.uint8Array(), (xs, ys) => {
+                const t0 = cmb(xs, ys);
+                const exp = new Uint8Array(xs.length + ys.length);
+                exp.set(xs);
+                exp.set(ys, xs.length);
+                assert.deepEqual(t0, exp);
+                assert.strictEqual(exp.length, xs.length + ys.length);
+            }),
+        );
+    });
+});

--- a/test/uint8_clamped_array_test.ts
+++ b/test/uint8_clamped_array_test.ts
@@ -1,0 +1,56 @@
+import { cmb } from "@neotype/prelude/cmb.js";
+import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { assert } from "chai";
+import * as fc from "fast-check";
+import "../src/uint8_clamped_array.js";
+
+describe("Uint8ClampedArray", () => {
+    specify("[Eq.eq]", () => {
+        fc.assert(
+            fc.property(
+                fc.uint8ClampedArray(),
+                fc.uint8ClampedArray(),
+                (xs, ys) => {
+                    const t0 = eq(xs, ys);
+                    assert.strictEqual(
+                        t0,
+                        ieqBy(xs, ys, (x, y) => x === y),
+                    );
+                },
+            ),
+        );
+    });
+
+    specify("[Ord.cmp]", () => {
+        fc.assert(
+            fc.property(
+                fc.uint8ClampedArray(),
+                fc.uint8ClampedArray(),
+                (xs, ys) => {
+                    const t0 = cmp(xs, ys);
+                    assert.strictEqual(
+                        t0,
+                        icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+                    );
+                },
+            ),
+        );
+    });
+
+    specify("[Semigroup.cmb]", () => {
+        fc.assert(
+            fc.property(
+                fc.uint8ClampedArray(),
+                fc.uint8ClampedArray(),
+                (xs, ys) => {
+                    const t0 = cmb(xs, ys);
+                    const exp = new Uint8ClampedArray(xs.length + ys.length);
+                    exp.set(xs);
+                    exp.set(ys, xs.length);
+                    assert.deepEqual(t0, exp);
+                    assert.strictEqual(exp.length, xs.length + ys.length);
+                },
+            ),
+        );
+    });
+});


### PR DESCRIPTION
This introduces `Eq`, `Ord`, and `Semigroup` implementations for all of the `TypedArray` classes.