### PR TITLE
Upgrade Neotype to v0.6 and TypeScript to v4.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.0",
             "license": "Apache-2.0",
             "devDependencies": {
-                "@neotype/prelude": "^0.5",
+                "@neotype/prelude": "^0.6",
                 "@types/chai": "^4.3.1",
                 "@types/mocha": "^9.1.1",
                 "@typescript-eslint/eslint-plugin": "^5.30.5",
@@ -24,13 +24,13 @@
                 "prettier-plugin-organize-imports": "^3.1.1",
                 "rimraf": "^3.0.2",
                 "ts-node": "^10.8.2",
-                "typescript": "~4.8"
+                "typescript": "~4.9"
             },
             "engines": {
                 "node": "16.* || >= 18.*"
             },
             "peerDependencies": {
-                "@neotype/prelude": "^0.5"
+                "@neotype/prelude": "^0.6"
             }
         },
         "node_modules/@cspotcode/source-map-support": {
@@ -137,9 +137,9 @@
             }
         },
         "node_modules/@neotype/prelude": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@neotype/prelude/-/prelude-0.5.0.tgz",
-            "integrity": "sha512-z7N1zp3RuAdgefgDIHIa1HZjkGMeX7n9pWDpGyQyDi/BKKk1VywqJLXkHOm0l2Hn22+hTfA8mqu3l7MBACzs1A==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@neotype/prelude/-/prelude-0.6.0.tgz",
+            "integrity": "sha512-yrh39dPpntYp3YrUSW3NwZqXAEBraR7uhv1XeCmU4zCQZzlxXTBvb3gXD6ozmFXXBtS2PemcdaJgIb2kckZfzw==",
             "dev": true,
             "engines": {
                 "node": "16.* || >= 18.*"
@@ -3007,9 +3007,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.8.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-            "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+            "version": "4.9.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+            "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -3276,9 +3276,9 @@
             }
         },
         "@neotype/prelude": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@neotype/prelude/-/prelude-0.5.0.tgz",
-            "integrity": "sha512-z7N1zp3RuAdgefgDIHIa1HZjkGMeX7n9pWDpGyQyDi/BKKk1VywqJLXkHOm0l2Hn22+hTfA8mqu3l7MBACzs1A==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@neotype/prelude/-/prelude-0.6.0.tgz",
+            "integrity": "sha512-yrh39dPpntYp3YrUSW3NwZqXAEBraR7uhv1XeCmU4zCQZzlxXTBvb3gXD6ozmFXXBtS2PemcdaJgIb2kckZfzw==",
             "dev": true
         },
         "@nodelib/fs.scandir": {
@@ -5304,9 +5304,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "4.8.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-            "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+            "version": "4.9.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+            "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
             "dev": true
         },
         "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -69,10 +69,10 @@
         "postpublish": "npm run clean"
     },
     "peerDependencies": {
-        "@neotype/prelude": "^0.5"
+        "@neotype/prelude": "^0.6"
     },
     "devDependencies": {
-        "@neotype/prelude": "^0.5",
+        "@neotype/prelude": "^0.6",
         "@types/chai": "^4.3.1",
         "@types/mocha": "^9.1.1",
         "@typescript-eslint/eslint-plugin": "^5.30.5",
@@ -87,7 +87,7 @@
         "prettier-plugin-organize-imports": "^3.1.1",
         "rimraf": "^3.0.2",
         "ts-node": "^10.8.2",
-        "typescript": "~4.8"
+        "typescript": "~4.9"
     },
     "eslintConfig": {
         "env": {

--- a/src/bigint.ts
+++ b/src/bigint.ts
@@ -49,12 +49,6 @@ BigInt.prototype[Eq.eq] = function (that: bigint): boolean {
     return this === that;
 };
 
-BigInt.prototype[Ord.cmp] = function (that: bigint): Ordering {
-    if (this < that) {
-        return Ordering.less;
-    }
-    if (this > that) {
-        return Ordering.greater;
-    }
-    return Ordering.equal;
+BigInt.prototype[Ord.cmp] = function (this: bigint, that: bigint): Ordering {
+    return Ordering.fromNumber(this - that);
 };

--- a/src/bigint64_array.ts
+++ b/src/bigint64_array.ts
@@ -61,16 +61,7 @@ BigInt64Array.prototype[Eq.eq] = function (that: BigInt64Array): boolean {
 };
 
 BigInt64Array.prototype[Ord.cmp] = function (that: BigInt64Array): Ordering {
-    return icmpBy(this, that, (x, y) => {
-        const n = x - y;
-        if (n < 0) {
-            return Ordering.less;
-        }
-        if (n > 0) {
-            return Ordering.greater;
-        }
-        return Ordering.equal;
-    });
+    return icmpBy(this, that, (x, y) => Ordering.fromNumber(x - y));
 };
 
 BigInt64Array.prototype[Semigroup.cmb] = function (

--- a/src/biguint64_array.ts
+++ b/src/biguint64_array.ts
@@ -61,16 +61,7 @@ BigUint64Array.prototype[Eq.eq] = function (that: BigUint64Array): boolean {
 };
 
 BigUint64Array.prototype[Ord.cmp] = function (that: BigUint64Array): Ordering {
-    return icmpBy(this, that, (x, y) => {
-        const n = x - y;
-        if (n < 0) {
-            return Ordering.less;
-        }
-        if (n > 0) {
-            return Ordering.greater;
-        }
-        return Ordering.equal;
-    });
+    return icmpBy(this, that, (x, y) => Ordering.fromNumber(x - y));
 };
 
 BigUint64Array.prototype[Semigroup.cmb] = function (


### PR DESCRIPTION
For, `bigint`, `BigInt64Array`, and `BigUint64Array`, use `Ordering.fromNumber` for comparison now that `bigint` values are valid arguments.