### PR TITLE
Refactor the tests to use BDD-style assertions

### DIFF
--- a/src/set.ts
+++ b/src/set.ts
@@ -51,11 +51,13 @@ import { Eq } from "@neotype/prelude/cmp.js";
 declare global {
     interface Set<T> {
         [Eq.eq](that: Set<T>): boolean;
+
         [Semigroup.cmb](that: Set<T>): Set<T>;
     }
 
     interface ReadonlySet<T> {
         [Eq.eq](that: ReadonlySet<T>): boolean;
+
         [Semigroup.cmb](that: ReadonlySet<T>): ReadonlySet<T>;
     }
 }
@@ -77,9 +79,9 @@ Set.prototype[Semigroup.cmb] = function <T>(
     that: Set<T>,
 ): Set<T> {
     return new Set(
-        function* (this: Set<T>) {
-            yield* this;
+        (function* (self: Set<T>) {
+            yield* self;
             yield* that;
-        }.call(this),
+        })(this),
     );
 };

--- a/test/array_test.ts
+++ b/test/array_test.ts
@@ -1,120 +1,125 @@
 import { cmb } from "@neotype/prelude/cmb.js";
 import { cmp, eq, icmp, ieq } from "@neotype/prelude/cmp.js";
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import "../src/array.js";
 import "../src/number.js";
 import "../src/string.js";
 
-describe("Array", () => {
-    specify("[Eq.eq]", () => {
-        fc.assert(
-            fc.property(
-                fc.array(fc.float({ noNaN: true })),
-                fc.array(fc.float({ noNaN: true })),
-                (xs, ys) => {
-                    const t0 = eq(xs, ys);
-                    assert.strictEqual(t0, ieq(xs, ys));
+describe("array.js", () => {
+    describe("Array", () => {
+        specify("[Eq.eq]", () => {
+            fc.assert(
+                fc.property(
+                    fc.array(fc.float({ noNaN: true })),
+                    fc.array(fc.float({ noNaN: true })),
+                    (xs, ys) => {
+                        expect(eq(xs, ys)).to.equal(ieq(xs, ys));
+                    },
+                ),
+            );
+        });
 
-                    const t1 = eq(xs as readonly number[], ys);
-                    assert.strictEqual(t1, ieq(xs, ys));
+        specify("[Ord.cmp]", () => {
+            fc.assert(
+                fc.property(
+                    fc.array(fc.float({ noNaN: true })),
+                    fc.array(fc.float({ noNaN: true })),
+                    (xs, ys) => {
+                        expect(cmp(xs, ys)).to.equal(icmp(xs, ys));
+                    },
+                ),
+            );
+        });
 
-                    const t2 = eq(xs, ys as readonly number[]);
-                    assert.strictEqual(t2, ieq(xs, ys));
-                },
-            ),
-        );
+        specify("[Semigroup.cmb]", () => {
+            fc.assert(
+                fc.property(
+                    fc.array(fc.anything()),
+                    fc.array(fc.anything()),
+                    (xs, ys) => {
+                        expect(cmb(xs, ys)).to.equal([...xs, ...ys]);
+                    },
+                ),
+            );
+        });
     });
 
-    specify("[Ord.cmp]", () => {
-        fc.assert(
-            fc.property(
-                fc.array(fc.float({ noNaN: true })),
-                fc.array(fc.float({ noNaN: true })),
-                (xs, ys) => {
-                    const t0 = cmp(xs, ys);
-                    assert.strictEqual(t0, icmp(xs, ys));
+    describe("ReadonlyArray", () => {
+        specify("[Eq.eq]", () => {
+            const xs: readonly number[] = [];
+            const ys: number[] = [];
+            eq(xs, xs);
+            eq(xs, ys);
+            eq(ys, xs);
+        });
 
-                    const t1 = cmp(xs as readonly number[], ys);
-                    assert.strictEqual(t1, icmp(xs, ys));
+        specify("[Ord.cmp]", () => {
+            const xs: readonly number[] = [];
+            const ys: number[] = [];
+            cmp(xs, xs);
+            cmp(xs, ys);
+            cmp(ys, xs);
+        });
 
-                    const t2 = cmp(xs, ys as readonly number[]);
-                    assert.strictEqual(t2, icmp(xs, ys));
-                },
-            ),
-        );
+        specify("[Semigroup.cmb]", () => {
+            const xs: readonly unknown[] = [];
+            const ys: unknown[] = [];
+            cmb(xs, xs);
+            cmb(xs, ys);
+            cmb(ys, xs);
+        });
     });
 
-    specify("[Semigroup.cmb]", () => {
-        fc.assert(
-            fc.property(
-                fc.array(fc.float({ noNaN: true })),
-                fc.array(fc.float({ noNaN: true })),
-                (xs, ys) => {
-                    const t0 = cmb(xs, ys);
-                    assert.deepEqual(t0, [...xs, ...ys]);
-                },
-            ),
-        );
-    });
-});
+    describe("tuple literal", () => {
+        specify("[Eq.eq]", () => {
+            fc.assert(
+                fc.property(
+                    fc.float({ noNaN: true }),
+                    fc.string(),
+                    fc.float({ noNaN: true }),
+                    fc.string(),
+                    (a, x, b, y) => {
+                        const xs: [number, string] = [a, x];
+                        const ys: [number, string] = [b, y];
+                        expect(eq(xs, ys)).to.equal(eq(a, b) && eq(x, y));
+                    },
+                ),
+            );
+        });
 
-describe("tuple literal", () => {
-    specify("[Eq.eq]", () => {
-        fc.assert(
-            fc.property(
-                fc.float({ noNaN: true }),
-                fc.string(),
-                fc.float({ noNaN: true }),
-                fc.string(),
-                (a, x, b, y) => {
-                    const xs: [number, string] = [a, x];
-                    const ys: [number, string] = [b, y];
-                    const rxs = [a, x] as const;
-                    const rys = [b, y] as const;
-
-                    const t0 = eq(xs, ys);
-                    assert.strictEqual(t0, eq(a, b) && eq(x, y));
-
-                    const t1 = eq(xs, rys);
-                    assert.strictEqual(t1, eq(a, b) && eq(x, y));
-
-                    const t2 = eq(rxs, ys);
-                    assert.strictEqual(t2, eq(a, b) && eq(x, y));
-
-                    const t3 = eq(rxs, ys);
-                    assert.strictEqual(t3, eq(a, b) && eq(x, y));
-                },
-            ),
-        );
+        specify("[Ord.cmp]", () => {
+            fc.assert(
+                fc.property(
+                    fc.float({ noNaN: true }),
+                    fc.string(),
+                    fc.float({ noNaN: true }),
+                    fc.string(),
+                    (a, x, b, y) => {
+                        const xs: [number, string] = [a, x];
+                        const ys: [number, string] = [b, y];
+                        expect(cmp(xs, ys)).to.equal(cmb(cmp(a, b), cmp(x, y)));
+                    },
+                ),
+            );
+        });
     });
 
-    specify("[Ord.cmp]", () => {
-        fc.assert(
-            fc.property(
-                fc.float({ noNaN: true }),
-                fc.string(),
-                fc.float({ noNaN: true }),
-                fc.string(),
-                (a, x, b, y) => {
-                    const xs: [number, string] = [a, x];
-                    const ys: [number, string] = [b, y];
-                    const rxs = [a, x] as const;
-                    const rys = [b, y] as const;
+    describe("readonly tuple literal", () => {
+        specify("[Eq.eq]", () => {
+            const xs: readonly [number, string] = [0, ""];
+            const ys: [number, string] = [0, ""];
+            eq(xs, xs);
+            eq(xs, ys);
+            eq(ys, xs);
+        });
 
-                    const t0 = cmp(xs, ys);
-                    assert.strictEqual(t0, cmb(cmp(a, b), cmp(x, y)));
-
-                    const t1 = cmp(xs, rys);
-                    assert.strictEqual(t1, cmb(cmp(a, b), cmp(x, y)));
-
-                    const t2 = cmp(rxs, ys);
-                    assert.strictEqual(t2, cmb(cmp(a, b), cmp(x, y)));
-
-                    const t3 = cmp(rxs, ys);
-                    assert.strictEqual(t3, cmb(cmp(a, b), cmp(x, y)));
-                },
-            ),
-        );
+        specify("[Ord.cmp]", () => {
+            const xs: readonly [number, string] = [0, ""];
+            const ys: [number, string] = [0, ""];
+            cmp(xs, xs);
+            cmp(xs, ys);
+            cmp(ys, xs);
+        });
     });
 });

--- a/test/array_test.ts
+++ b/test/array_test.ts
@@ -38,7 +38,7 @@ describe("array.js", () => {
                     fc.array(fc.anything()),
                     fc.array(fc.anything()),
                     (xs, ys) => {
-                        expect(cmb(xs, ys)).to.equal([...xs, ...ys]);
+                        expect(cmb(xs, ys)).to.deep.equal([...xs, ...ys]);
                     },
                 ),
             );

--- a/test/array_test.ts
+++ b/test/array_test.ts
@@ -8,7 +8,7 @@ import "../src/string.js";
 
 describe("array.js", () => {
     describe("Array", () => {
-        specify("[Eq.eq]", () => {
+        specify("#[Eq.eq]", () => {
             fc.assert(
                 fc.property(
                     fc.array(fc.float({ noNaN: true })),
@@ -20,7 +20,7 @@ describe("array.js", () => {
             );
         });
 
-        specify("[Ord.cmp]", () => {
+        specify("#[Ord.cmp]", () => {
             fc.assert(
                 fc.property(
                     fc.array(fc.float({ noNaN: true })),
@@ -32,7 +32,7 @@ describe("array.js", () => {
             );
         });
 
-        specify("[Semigroup.cmb]", () => {
+        specify("#[Semigroup.cmb]", () => {
             fc.assert(
                 fc.property(
                     fc.array(fc.anything()),
@@ -46,7 +46,7 @@ describe("array.js", () => {
     });
 
     describe("ReadonlyArray", () => {
-        specify("[Eq.eq]", () => {
+        specify("#[Eq.eq]", () => {
             const xs: readonly number[] = [];
             const ys: number[] = [];
             eq(xs, xs);
@@ -54,7 +54,7 @@ describe("array.js", () => {
             eq(ys, xs);
         });
 
-        specify("[Ord.cmp]", () => {
+        specify("#[Ord.cmp]", () => {
             const xs: readonly number[] = [];
             const ys: number[] = [];
             cmp(xs, xs);
@@ -62,7 +62,7 @@ describe("array.js", () => {
             cmp(ys, xs);
         });
 
-        specify("[Semigroup.cmb]", () => {
+        specify("#[Semigroup.cmb]", () => {
             const xs: readonly unknown[] = [];
             const ys: unknown[] = [];
             cmb(xs, xs);
@@ -72,7 +72,7 @@ describe("array.js", () => {
     });
 
     describe("tuple literal", () => {
-        specify("[Eq.eq]", () => {
+        specify("#[Eq.eq]", () => {
             fc.assert(
                 fc.property(
                     fc.float({ noNaN: true }),
@@ -88,7 +88,7 @@ describe("array.js", () => {
             );
         });
 
-        specify("[Ord.cmp]", () => {
+        specify("#[Ord.cmp]", () => {
             fc.assert(
                 fc.property(
                     fc.float({ noNaN: true }),
@@ -106,7 +106,7 @@ describe("array.js", () => {
     });
 
     describe("readonly tuple literal", () => {
-        specify("[Eq.eq]", () => {
+        specify("#[Eq.eq]", () => {
             const xs: readonly [number, string] = [0, ""];
             const ys: [number, string] = [0, ""];
             eq(xs, xs);
@@ -114,7 +114,7 @@ describe("array.js", () => {
             eq(ys, xs);
         });
 
-        specify("[Ord.cmp]", () => {
+        specify("#[Ord.cmp]", () => {
             const xs: readonly [number, string] = [0, ""];
             const ys: [number, string] = [0, ""];
             cmp(xs, xs);

--- a/test/bigint64_array_test.ts
+++ b/test/bigint64_array_test.ts
@@ -1,50 +1,58 @@
 import { cmb } from "@neotype/prelude/cmb.js";
 import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import "../src/bigint64_array.js";
 
-describe("BigInt64Array", () => {
-    specify("[Eq.eq]", () => {
-        fc.assert(
-            fc.property(fc.bigInt64Array(), fc.bigInt64Array(), (xs, ys) => {
-                const t0 = eq(xs, ys);
-                assert.strictEqual(
-                    t0,
-                    ieqBy(xs, ys, (x, y) => x === y),
-                );
-            }),
-        );
-    });
+describe("bigint64_array.js", () => {
+    describe("BigInt64Array", () => {
+        specify("#[Eq.eq]", () => {
+            fc.assert(
+                fc.property(
+                    fc.bigInt64Array(),
+                    fc.bigInt64Array(),
+                    (xs, ys) => {
+                        expect(eq(xs, ys)).to.equal(
+                            ieqBy(xs, ys, (x, y) => x === y),
+                        );
+                    },
+                ),
+            );
+        });
 
-    specify("[Ord.cmp]", () => {
-        fc.assert(
-            fc.property(fc.bigInt64Array(), fc.bigInt64Array(), (xs, ys) => {
-                const t0 = cmp(xs, ys);
-                assert.strictEqual(
-                    t0,
-                    icmpBy(xs, ys, (x, y) =>
-                        x < y
-                            ? Ordering.less
-                            : x > y
-                            ? Ordering.greater
-                            : Ordering.equal,
-                    ),
-                );
-            }),
-        );
-    });
+        specify("#[Ord.cmp]", () => {
+            fc.assert(
+                fc.property(
+                    fc.bigInt64Array(),
+                    fc.bigInt64Array(),
+                    (xs, ys) => {
+                        expect(cmp(xs, ys)).to.equal(
+                            icmpBy(xs, ys, (x, y) =>
+                                Ordering.fromNumber(x - y),
+                            ),
+                        );
+                    },
+                ),
+            );
+        });
 
-    specify("[Semigroup.cmb]", () => {
-        fc.assert(
-            fc.property(fc.bigInt64Array(), fc.bigInt64Array(), (xs, ys) => {
-                const t0 = cmb(xs, ys);
-                const exp = new BigInt64Array(xs.length + ys.length);
-                exp.set(xs);
-                exp.set(ys, xs.length);
-                assert.deepEqual(t0, exp);
-                assert.strictEqual(exp.length, xs.length + ys.length);
-            }),
-        );
+        specify("#[Semigroup.cmb]", () => {
+            fc.assert(
+                fc.property(
+                    fc.bigInt64Array(),
+                    fc.bigInt64Array(),
+                    (xs, ys) => {
+                        const result = cmb(xs, ys);
+
+                        const exp = new BigInt64Array(xs.length + ys.length);
+                        exp.set(xs);
+                        exp.set(ys, xs.length);
+
+                        expect(result).to.deep.equal(exp);
+                        expect(exp.length).to.equal(xs.length + ys.length);
+                    },
+                ),
+            );
+        });
     });
 });

--- a/test/bigint_test.ts
+++ b/test/bigint_test.ts
@@ -5,7 +5,7 @@ import "../src/bigint.js";
 
 describe("bigint.js", () => {
     describe("BigInt", () => {
-        specify("[Eq.eq]", () => {
+        specify("#[Eq.eq]", () => {
             fc.assert(
                 fc.property(fc.bigInt(), fc.bigInt(), (x, y) => {
                     expect(eq(x, y)).to.equal(x === y);
@@ -13,7 +13,7 @@ describe("bigint.js", () => {
             );
         });
 
-        specify("[Ord.cmp]", () => {
+        specify("#[Ord.cmp]", () => {
             fc.assert(
                 fc.property(fc.bigInt(), fc.bigInt(), (x, y) => {
                     expect(cmp(x, y)).to.equal(Ordering.fromNumber(x - y));

--- a/test/bigint_test.ts
+++ b/test/bigint_test.ts
@@ -1,31 +1,24 @@
 import { cmp, eq, Ordering } from "@neotype/prelude/cmp.js";
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import "../src/bigint.js";
 
-describe("bigint", () => {
-    specify("[Eq.eq]", () => {
-        fc.assert(
-            fc.property(fc.bigInt(), fc.bigInt(), (x, y) => {
-                const t0 = eq(x, y);
-                assert.strictEqual(t0, x === y);
-            }),
-        );
-    });
+describe("bigint.js", () => {
+    describe("BigInt", () => {
+        specify("[Eq.eq]", () => {
+            fc.assert(
+                fc.property(fc.bigInt(), fc.bigInt(), (x, y) => {
+                    expect(eq(x, y)).to.equal(x === y);
+                }),
+            );
+        });
 
-    specify("[Ord.cmp]", () => {
-        fc.assert(
-            fc.property(fc.bigInt(), fc.bigInt(), (x, y) => {
-                const t0 = cmp(x, y);
-                assert.strictEqual(
-                    t0,
-                    x < y
-                        ? Ordering.less
-                        : x > y
-                        ? Ordering.greater
-                        : Ordering.equal,
-                );
-            }),
-        );
+        specify("[Ord.cmp]", () => {
+            fc.assert(
+                fc.property(fc.bigInt(), fc.bigInt(), (x, y) => {
+                    expect(cmp(x, y)).to.equal(Ordering.fromNumber(x - y));
+                }),
+            );
+        });
     });
 });

--- a/test/biguint64_array_test.ts
+++ b/test/biguint64_array_test.ts
@@ -1,50 +1,58 @@
 import { cmb } from "@neotype/prelude/cmb.js";
 import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import "../src/biguint64_array.js";
 
-describe("BigUint64Array", () => {
-    specify("[Eq.eq]", () => {
-        fc.assert(
-            fc.property(fc.bigUint64Array(), fc.bigUint64Array(), (xs, ys) => {
-                const t0 = eq(xs, ys);
-                assert.strictEqual(
-                    t0,
-                    ieqBy(xs, ys, (x, y) => x === y),
-                );
-            }),
-        );
-    });
+describe("biguint64_array.js", () => {
+    describe("BigUint64Array", () => {
+        specify("#[Eq.eq]", () => {
+            fc.assert(
+                fc.property(
+                    fc.bigUint64Array(),
+                    fc.bigUint64Array(),
+                    (xs, ys) => {
+                        expect(eq(xs, ys)).to.equal(
+                            ieqBy(xs, ys, (x, y) => x === y),
+                        );
+                    },
+                ),
+            );
+        });
 
-    specify("[Ord.cmp]", () => {
-        fc.assert(
-            fc.property(fc.bigUint64Array(), fc.bigUint64Array(), (xs, ys) => {
-                const t0 = cmp(xs, ys);
-                assert.strictEqual(
-                    t0,
-                    icmpBy(xs, ys, (x, y) =>
-                        x < y
-                            ? Ordering.less
-                            : x > y
-                            ? Ordering.greater
-                            : Ordering.equal,
-                    ),
-                );
-            }),
-        );
-    });
+        specify("#[Ord.cmp]", () => {
+            fc.assert(
+                fc.property(
+                    fc.bigUint64Array(),
+                    fc.bigUint64Array(),
+                    (xs, ys) => {
+                        expect(cmp(xs, ys)).to.equal(
+                            icmpBy(xs, ys, (x, y) =>
+                                Ordering.fromNumber(x - y),
+                            ),
+                        );
+                    },
+                ),
+            );
+        });
 
-    specify("[Semigroup.cmb]", () => {
-        fc.assert(
-            fc.property(fc.bigUint64Array(), fc.bigUint64Array(), (xs, ys) => {
-                const t0 = cmb(xs, ys);
-                const exp = new BigUint64Array(xs.length + ys.length);
-                exp.set(xs);
-                exp.set(ys, xs.length);
-                assert.deepEqual(t0, exp);
-                assert.strictEqual(exp.length, xs.length + ys.length);
-            }),
-        );
+        specify("#[Semigroup.cmb]", () => {
+            fc.assert(
+                fc.property(
+                    fc.bigUint64Array(),
+                    fc.bigUint64Array(),
+                    (xs, ys) => {
+                        const result = cmb(xs, ys);
+
+                        const exp = new BigUint64Array(xs.length + ys.length);
+                        exp.set(xs);
+                        exp.set(ys, xs.length);
+
+                        expect(result).to.deep.equal(exp);
+                        expect(exp.length).to.equal(xs.length + ys.length);
+                    },
+                ),
+            );
+        });
     });
 });

--- a/test/boolean_test.ts
+++ b/test/boolean_test.ts
@@ -1,31 +1,26 @@
 import { cmp, eq, Ordering } from "@neotype/prelude/cmp.js";
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import "../src/boolean.js";
 
-describe("boolean", () => {
-    specify("[Eq.eq]", () => {
-        fc.assert(
-            fc.property(fc.boolean(), fc.boolean(), (x, y) => {
-                const t0 = eq(x, y);
-                assert.strictEqual(t0, x === y);
-            }),
-        );
-    });
+describe("boolean.js", () => {
+    describe("Boolean", () => {
+        specify("#[Eq.eq]", () => {
+            fc.assert(
+                fc.property(fc.boolean(), fc.boolean(), (x, y) => {
+                    expect(eq(x, y)).to.equal(x === y);
+                }),
+            );
+        });
 
-    specify("[Ord.cmp]", () => {
-        fc.assert(
-            fc.property(fc.boolean(), fc.boolean(), (x, y) => {
-                const t0 = cmp(x, y);
-                assert.strictEqual(
-                    t0,
-                    x < y
-                        ? Ordering.less
-                        : x > y
-                        ? Ordering.greater
-                        : Ordering.equal,
-                );
-            }),
-        );
+        specify("#[Ord.cmp]", () => {
+            fc.assert(
+                fc.property(fc.boolean(), fc.boolean(), (x, y) => {
+                    expect(cmp(x, y)).to.equal(
+                        Ordering.fromNumber(Number(x) - Number(y)),
+                    );
+                }),
+            );
+        });
     });
 });

--- a/test/date_test.ts
+++ b/test/date_test.ts
@@ -1,31 +1,26 @@
 import { cmp, eq, Ordering } from "@neotype/prelude/cmp.js";
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import "../src/date.js";
 
-describe("Date", () => {
-    specify("[Eq.eq]", () => {
-        fc.assert(
-            fc.property(fc.date(), fc.date(), (x, y) => {
-                const t0 = eq(x, y);
-                assert.strictEqual(t0, x.getTime() === y.getTime());
-            }),
-        );
-    });
+describe("date.js", () => {
+    describe("Date", () => {
+        specify("#[Eq.eq]", () => {
+            fc.assert(
+                fc.property(fc.date(), fc.date(), (x, y) => {
+                    expect(eq(x, y)).to.equal(x.getTime() === y.getTime());
+                }),
+            );
+        });
 
-    specify("[Ord.cmp]", () => {
-        fc.assert(
-            fc.property(fc.date(), fc.date(), (x, y) => {
-                const t0 = cmp(x, y);
-                assert.strictEqual(
-                    t0,
-                    x < y
-                        ? Ordering.less
-                        : x > y
-                        ? Ordering.greater
-                        : Ordering.equal,
-                );
-            }),
-        );
+        specify("#[Ord.cmp]", () => {
+            fc.assert(
+                fc.property(fc.date(), fc.date(), (x, y) => {
+                    expect(cmp(x, y)).to.equal(
+                        Ordering.fromNumber(x.getTime() - y.getTime()),
+                    );
+                }),
+            );
+        });
     });
 });

--- a/test/float32_array_test.ts
+++ b/test/float32_array_test.ts
@@ -1,44 +1,44 @@
 import { cmb } from "@neotype/prelude/cmb.js";
 import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import "../src/float32_array.js";
 
-describe("Float32Array", () => {
-    specify("[Eq.eq]", () => {
-        fc.assert(
-            fc.property(fc.float32Array(), fc.float32Array(), (xs, ys) => {
-                const t0 = eq(xs, ys);
-                assert.strictEqual(
-                    t0,
-                    ieqBy(xs, ys, (x, y) => x === y),
-                );
-            }),
-        );
-    });
+describe("float32_array.js", () => {
+    describe("Float32Array", () => {
+        specify("#[Eq.eq]", () => {
+            fc.assert(
+                fc.property(fc.float32Array(), fc.float32Array(), (xs, ys) => {
+                    expect(eq(xs, ys)).to.equal(
+                        ieqBy(xs, ys, (x, y) => x === y),
+                    );
+                }),
+            );
+        });
 
-    specify("[Ord.cmp]", () => {
-        fc.assert(
-            fc.property(fc.float32Array(), fc.float32Array(), (xs, ys) => {
-                const t0 = cmp(xs, ys);
-                assert.strictEqual(
-                    t0,
-                    icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
-                );
-            }),
-        );
-    });
+        specify("#[Ord.cmp]", () => {
+            fc.assert(
+                fc.property(fc.float32Array(), fc.float32Array(), (xs, ys) => {
+                    expect(cmp(xs, ys)).to.equal(
+                        icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+                    );
+                }),
+            );
+        });
 
-    specify("[Semigroup.cmb]", () => {
-        fc.assert(
-            fc.property(fc.float32Array(), fc.float32Array(), (xs, ys) => {
-                const t0 = cmb(xs, ys);
-                const exp = new Float32Array(xs.length + ys.length);
-                exp.set(xs);
-                exp.set(ys, xs.length);
-                assert.deepEqual(t0, exp);
-                assert.strictEqual(exp.length, xs.length + ys.length);
-            }),
-        );
+        specify("#[Semigroup.cmb]", () => {
+            fc.assert(
+                fc.property(fc.float32Array(), fc.float32Array(), (xs, ys) => {
+                    const result = cmb(xs, ys);
+
+                    const exp = new Float32Array(xs.length + ys.length);
+                    exp.set(xs);
+                    exp.set(ys, xs.length);
+
+                    expect(result).to.deep.equal(exp);
+                    expect(exp.length).to.equal(xs.length + ys.length);
+                }),
+            );
+        });
     });
 });

--- a/test/float64_array_test.ts
+++ b/test/float64_array_test.ts
@@ -1,44 +1,44 @@
 import { cmb } from "@neotype/prelude/cmb.js";
 import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import "../src/float64_array.js";
 
-describe("Float64Array", () => {
-    specify("[Eq.eq]", () => {
-        fc.assert(
-            fc.property(fc.float64Array(), fc.float64Array(), (xs, ys) => {
-                const t0 = eq(xs, ys);
-                assert.strictEqual(
-                    t0,
-                    ieqBy(xs, ys, (x, y) => x === y),
-                );
-            }),
-        );
-    });
+describe("float64_array.js", () => {
+    describe("Float64Array", () => {
+        specify("#[Eq.eq]", () => {
+            fc.assert(
+                fc.property(fc.float64Array(), fc.float64Array(), (xs, ys) => {
+                    expect(eq(xs, ys)).to.equal(
+                        ieqBy(xs, ys, (x, y) => x === y),
+                    );
+                }),
+            );
+        });
 
-    specify("[Ord.cmp]", () => {
-        fc.assert(
-            fc.property(fc.float64Array(), fc.float64Array(), (xs, ys) => {
-                const t0 = cmp(xs, ys);
-                assert.strictEqual(
-                    t0,
-                    icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
-                );
-            }),
-        );
-    });
+        specify("#[Ord.cmp]", () => {
+            fc.assert(
+                fc.property(fc.float64Array(), fc.float64Array(), (xs, ys) => {
+                    expect(cmp(xs, ys)).to.equal(
+                        icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+                    );
+                }),
+            );
+        });
 
-    specify("[Semigroup.cmb]", () => {
-        fc.assert(
-            fc.property(fc.float64Array(), fc.float64Array(), (xs, ys) => {
-                const t0 = cmb(xs, ys);
-                const exp = new Float64Array(xs.length + ys.length);
-                exp.set(xs);
-                exp.set(ys, xs.length);
-                assert.deepEqual(t0, exp);
-                assert.strictEqual(exp.length, xs.length + ys.length);
-            }),
-        );
+        specify("#[Semigroup.cmb]", () => {
+            fc.assert(
+                fc.property(fc.float64Array(), fc.float64Array(), (xs, ys) => {
+                    const result = cmb(xs, ys);
+
+                    const exp = new Float64Array(xs.length + ys.length);
+                    exp.set(xs);
+                    exp.set(ys, xs.length);
+
+                    expect(result).to.deep.equal(exp);
+                    expect(exp.length).to.equal(xs.length + ys.length);
+                }),
+            );
+        });
     });
 });

--- a/test/function_test.ts
+++ b/test/function_test.ts
@@ -1,18 +1,20 @@
 import { cmb } from "@neotype/prelude/cmb.js";
 import { id } from "@neotype/prelude/fn.js";
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import "../src/function.js";
 import "../src/string.js";
 
-describe("Function", () => {
-    specify("[Semigroup.cmb]", () => {
-        fc.assert(
-            fc.property(fc.string(), (x) => {
-                const f0 = cmb(id<string>, id);
-                const t0 = f0(x);
-                assert.strictEqual(t0, cmb(x, x));
-            }),
-        );
+describe("function.js", () => {
+    describe("Function", () => {
+        specify("#[Semigroup.cmb]", () => {
+            fc.assert(
+                fc.property(fc.string(), (x) => {
+                    const f = cmb(id<string>, id);
+                    const result = f(x);
+                    expect(result).to.equal(cmb(x, x));
+                }),
+            );
+        });
     });
 });

--- a/test/int16_array_test.ts
+++ b/test/int16_array_test.ts
@@ -1,44 +1,44 @@
 import { cmb } from "@neotype/prelude/cmb.js";
 import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import "../src/int16_array.js";
 
-describe("Int16Array", () => {
-    specify("[Eq.eq]", () => {
-        fc.assert(
-            fc.property(fc.int16Array(), fc.int16Array(), (xs, ys) => {
-                const t0 = eq(xs, ys);
-                assert.strictEqual(
-                    t0,
-                    ieqBy(xs, ys, (x, y) => x === y),
-                );
-            }),
-        );
-    });
+describe("int16_array.js", () => {
+    describe("Int16Array", () => {
+        specify("#[Eq.eq]", () => {
+            fc.assert(
+                fc.property(fc.int16Array(), fc.int16Array(), (xs, ys) => {
+                    expect(eq(xs, ys)).to.equal(
+                        ieqBy(xs, ys, (x, y) => x === y),
+                    );
+                }),
+            );
+        });
 
-    specify("[Ord.cmp]", () => {
-        fc.assert(
-            fc.property(fc.int16Array(), fc.int16Array(), (xs, ys) => {
-                const t0 = cmp(xs, ys);
-                assert.strictEqual(
-                    t0,
-                    icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
-                );
-            }),
-        );
-    });
+        specify("#[Ord.cmp]", () => {
+            fc.assert(
+                fc.property(fc.int16Array(), fc.int16Array(), (xs, ys) => {
+                    expect(cmp(xs, ys)).to.equal(
+                        icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+                    );
+                }),
+            );
+        });
 
-    specify("[Semigroup.cmb]", () => {
-        fc.assert(
-            fc.property(fc.int16Array(), fc.int16Array(), (xs, ys) => {
-                const t0 = cmb(xs, ys);
-                const exp = new Int16Array(xs.length + ys.length);
-                exp.set(xs);
-                exp.set(ys, xs.length);
-                assert.deepEqual(t0, exp);
-                assert.strictEqual(exp.length, xs.length + ys.length);
-            }),
-        );
+        specify("#[Semigroup.cmb]", () => {
+            fc.assert(
+                fc.property(fc.int16Array(), fc.int16Array(), (xs, ys) => {
+                    const result = cmb(xs, ys);
+
+                    const exp = new Int16Array(xs.length + ys.length);
+                    exp.set(xs);
+                    exp.set(ys, xs.length);
+
+                    expect(result).to.deep.equal(exp);
+                    expect(exp.length).to.equal(xs.length + ys.length);
+                }),
+            );
+        });
     });
 });

--- a/test/int32_array_test.ts
+++ b/test/int32_array_test.ts
@@ -1,44 +1,44 @@
 import { cmb } from "@neotype/prelude/cmb.js";
 import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import "../src/int32_array.js";
 
-describe("Int32Array", () => {
-    specify("[Eq.eq]", () => {
-        fc.assert(
-            fc.property(fc.int32Array(), fc.int32Array(), (xs, ys) => {
-                const t0 = eq(xs, ys);
-                assert.strictEqual(
-                    t0,
-                    ieqBy(xs, ys, (x, y) => x === y),
-                );
-            }),
-        );
-    });
+describe("int32_array.js", () => {
+    describe("Int32Array", () => {
+        specify("#[Eq.eq]", () => {
+            fc.assert(
+                fc.property(fc.int32Array(), fc.int32Array(), (xs, ys) => {
+                    expect(eq(xs, ys)).to.equal(
+                        ieqBy(xs, ys, (x, y) => x === y),
+                    );
+                }),
+            );
+        });
 
-    specify("[Ord.cmp]", () => {
-        fc.assert(
-            fc.property(fc.int32Array(), fc.int32Array(), (xs, ys) => {
-                const t0 = cmp(xs, ys);
-                assert.strictEqual(
-                    t0,
-                    icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
-                );
-            }),
-        );
-    });
+        specify("#[Ord.cmp]", () => {
+            fc.assert(
+                fc.property(fc.int32Array(), fc.int32Array(), (xs, ys) => {
+                    expect(cmp(xs, ys)).to.equal(
+                        icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+                    );
+                }),
+            );
+        });
 
-    specify("[Semigroup.cmb]", () => {
-        fc.assert(
-            fc.property(fc.int32Array(), fc.int32Array(), (xs, ys) => {
-                const t0 = cmb(xs, ys);
-                const exp = new Int32Array(xs.length + ys.length);
-                exp.set(xs);
-                exp.set(ys, xs.length);
-                assert.deepEqual(t0, exp);
-                assert.strictEqual(exp.length, xs.length + ys.length);
-            }),
-        );
+        specify("#[Semigroup.cmb]", () => {
+            fc.assert(
+                fc.property(fc.int32Array(), fc.int32Array(), (xs, ys) => {
+                    const result = cmb(xs, ys);
+
+                    const exp = new Int32Array(xs.length + ys.length);
+                    exp.set(xs);
+                    exp.set(ys, xs.length);
+
+                    expect(result).to.deep.equal(exp);
+                    expect(exp.length).to.equal(xs.length + ys.length);
+                }),
+            );
+        });
     });
 });

--- a/test/int8_array_test.ts
+++ b/test/int8_array_test.ts
@@ -1,44 +1,44 @@
 import { cmb } from "@neotype/prelude/cmb.js";
 import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import "../src/int8_array.js";
 
-describe("Int8Array", () => {
-    specify("[Eq.eq]", () => {
-        fc.assert(
-            fc.property(fc.int8Array(), fc.int8Array(), (xs, ys) => {
-                const t0 = eq(xs, ys);
-                assert.strictEqual(
-                    t0,
-                    ieqBy(xs, ys, (x, y) => x === y),
-                );
-            }),
-        );
-    });
+describe("int8_array.js", () => {
+    describe("Int8Array", () => {
+        specify("#[Eq.eq]", () => {
+            fc.assert(
+                fc.property(fc.int8Array(), fc.int8Array(), (xs, ys) => {
+                    expect(eq(xs, ys)).to.equal(
+                        ieqBy(xs, ys, (x, y) => x === y),
+                    );
+                }),
+            );
+        });
 
-    specify("[Ord.cmp]", () => {
-        fc.assert(
-            fc.property(fc.int8Array(), fc.int8Array(), (xs, ys) => {
-                const t0 = cmp(xs, ys);
-                assert.strictEqual(
-                    t0,
-                    icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
-                );
-            }),
-        );
-    });
+        specify("#[Ord.cmp]", () => {
+            fc.assert(
+                fc.property(fc.int8Array(), fc.int8Array(), (xs, ys) => {
+                    expect(cmp(xs, ys)).to.equal(
+                        icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+                    );
+                }),
+            );
+        });
 
-    specify("[Semigroup.cmb]", () => {
-        fc.assert(
-            fc.property(fc.int8Array(), fc.int8Array(), (xs, ys) => {
-                const t0 = cmb(xs, ys);
-                const exp = new Int8Array(xs.length + ys.length);
-                exp.set(xs);
-                exp.set(ys, xs.length);
-                assert.deepEqual(t0, exp);
-                assert.strictEqual(exp.length, xs.length + ys.length);
-            }),
-        );
+        specify("#[Semigroup.cmb]", () => {
+            fc.assert(
+                fc.property(fc.int8Array(), fc.int8Array(), (xs, ys) => {
+                    const result = cmb(xs, ys);
+
+                    const exp = new Int8Array(xs.length + ys.length);
+                    exp.set(xs);
+                    exp.set(ys, xs.length);
+
+                    expect(result).to.deep.equal(exp);
+                    expect(exp.length).to.equal(xs.length + ys.length);
+                }),
+            );
+        });
     });
 });

--- a/test/map_test.ts
+++ b/test/map_test.ts
@@ -47,7 +47,13 @@ describe("map.js", () => {
                         .map((entries) => new Map(entries)),
                     (xs, ys) => {
                         const result = cmb(xs, ys);
-                        expect(result).to.deep.equal(new Map([...xs, ...ys]));
+                        const exp = new Map([...xs, ...ys]);
+
+                        expect(result.size).to.equal(exp.size);
+                        for (const [kx, x] of result) {
+                            expect(exp.has(kx)).to.be.true;
+                            expect(exp.get(kx)).to.equal(x);
+                        }
                     },
                 ),
             );

--- a/test/map_test.ts
+++ b/test/map_test.ts
@@ -1,187 +1,74 @@
 import { cmb } from "@neotype/prelude/cmb.js";
 import { eq } from "@neotype/prelude/cmp.js";
-import { assert } from "chai";
+import { expect } from "chai";
+import * as fc from "fast-check";
 import "../src/map.js";
 
-describe("Map", () => {
-    specify("[Eq.eq]", () => {
-        const t0 = eq(
-            new Map([
-                ["a", 1],
-                ["b", 2],
-            ]),
-            new Map([
-                ["a", 1],
-                ["b", 2],
-            ]),
-        );
-        assert.strictEqual(t0, true);
+describe("map.js", () => {
+    describe("Map", () => {
+        specify("#[Eq.eq]", () => {
+            fc.assert(
+                fc.property(
+                    fc
+                        .array(fc.tuple(fc.anything(), fc.anything()))
+                        .map((entries) => new Map(entries)),
+                    fc
+                        .array(fc.tuple(fc.anything(), fc.anything()))
+                        .map((entries) => new Map(entries)),
+                    (xs, ys) => {
+                        const result = eq(xs, ys);
 
-        const t1 = eq(
-            new Map([
-                ["a", 1],
-                ["b", 2],
-            ]),
-            new Map([
-                ["b", 2],
-                ["a", 1],
-            ]),
-        );
-        assert.strictEqual(t1, true);
+                        const exp = (() => {
+                            if (xs.size !== ys.size) {
+                                return false;
+                            }
+                            for (const [kx, x] of xs.entries()) {
+                                if (!(ys.has(kx) && ys.get(kx) === x)) {
+                                    return false;
+                                }
+                            }
+                            return true;
+                        })();
 
-        const t2 = eq(
-            new Map([
-                ["a", 1],
-                ["b", 2],
-            ]),
-            new Map([
-                ["b", 2],
-                ["a", 1],
-                ["c", 3],
-            ]),
-        );
-        assert.strictEqual(t2, false);
+                        expect(result).to.equal(exp);
+                    },
+                ),
+            );
+        });
 
-        const t3 = eq(
-            new Map([
-                ["a", 1],
-                ["b", 2],
-            ]),
-            new Map([
-                ["a", 1],
-                ["b", 3],
-            ]),
-        );
-        assert.strictEqual(t3, false);
-
-        const t4 = eq(
-            new Map([
-                ["a", 1],
-                ["b", 2],
-            ]),
-            new Map([
-                ["a", 1],
-                ["c", 2],
-            ]),
-        );
-        assert.strictEqual(t4, false);
-
-        const t5 = eq(
-            new Map([
-                ["a", 1],
-                ["b", 2],
-            ]) as ReadonlyMap<string, number>,
-            new Map([
-                ["a", 1],
-                ["b", 2],
-            ]),
-        );
-        assert.strictEqual(t5, true);
-
-        const t6 = eq(
-            new Map([
-                ["a", 1],
-                ["b", 2],
-            ]),
-            new Map([
-                ["b", 2],
-                ["a", 1],
-            ]) as ReadonlyMap<string, number>,
-        );
-        assert.strictEqual(t6, true);
+        specify("#[Semigroup.cmb]", () => {
+            fc.assert(
+                fc.property(
+                    fc
+                        .array(fc.tuple(fc.anything(), fc.anything()))
+                        .map((entries) => new Map(entries)),
+                    fc
+                        .array(fc.tuple(fc.anything(), fc.anything()))
+                        .map((entries) => new Map(entries)),
+                    (xs, ys) => {
+                        const result = cmb(xs, ys);
+                        expect(result).to.deep.equal(new Map([...xs, ...ys]));
+                    },
+                ),
+            );
+        });
     });
 
-    specify("[Semigroup.cmb]", () => {
-        const t0 = cmb(
-            new Map([
-                ["a", 1],
-                ["b", 2],
-            ]),
-            new Map([
-                ["a", 1],
-                ["b", 2],
-            ]),
-        );
-        assert.deepEqual(
-            t0,
-            new Map([
-                ["a", 1],
-                ["b", 2],
-            ]),
-        );
+    describe("ReadonlyMap", () => {
+        specify("#[Eq.eq]", () => {
+            const xs: ReadonlyMap<unknown, unknown> = new Map();
+            const ys: Map<unknown, unknown> = new Map();
+            eq(xs, xs);
+            eq(xs, ys);
+            eq(ys, xs);
+        });
 
-        const t1 = cmb(
-            new Map([
-                ["a", 1],
-                ["b", 2],
-            ]),
-            new Map([
-                ["a", 1],
-                ["b", 3],
-            ]),
-        );
-        assert.deepEqual(
-            t1,
-            new Map([
-                ["a", 1],
-                ["b", 3],
-            ]),
-        );
-
-        const t2 = cmb(
-            new Map([
-                ["a", 1],
-                ["b", 2],
-            ]),
-            new Map([
-                ["a", 1],
-                ["b", 2],
-                ["c", 3],
-            ]),
-        );
-        assert.deepEqual(
-            t2,
-            new Map([
-                ["a", 1],
-                ["b", 2],
-                ["c", 3],
-            ]),
-        );
-
-        const t3 = cmb(
-            new Map([
-                ["a", 1],
-                ["b", 2],
-            ]) as ReadonlyMap<string, number>,
-            new Map([
-                ["a", 1],
-                ["b", 2],
-            ]),
-        );
-        assert.deepEqual(
-            t3,
-            new Map([
-                ["a", 1],
-                ["b", 2],
-            ]),
-        );
-
-        const t4 = cmb(
-            new Map([
-                ["a", 1],
-                ["b", 2],
-            ]),
-            new Map([
-                ["a", 1],
-                ["b", 2],
-            ]) as ReadonlyMap<string, number>,
-        );
-        assert.deepEqual(
-            t4,
-            new Map([
-                ["a", 1],
-                ["b", 2],
-            ]),
-        );
+        specify("#[Semigroup.cmb]", () => {
+            const xs: ReadonlyMap<unknown, unknown> = new Map();
+            const ys: Map<unknown, unknown> = new Map();
+            cmb(xs, xs);
+            cmb(xs, ys);
+            cmb(ys, xs);
+        });
     });
 });

--- a/test/number_test.ts
+++ b/test/number_test.ts
@@ -1,39 +1,32 @@
 import { cmp, eq, Ordering } from "@neotype/prelude/cmp.js";
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import "../src/number.js";
 
-describe("number", () => {
-    specify("[Eq.eq]", () => {
-        fc.assert(
-            fc.property(
-                fc.float({ noNaN: true }),
-                fc.float({ noNaN: true }),
-                (x, y) => {
-                    const t0 = eq(x, y);
-                    assert.strictEqual(t0, x === y);
-                },
-            ),
-        );
-    });
+describe("number.js", () => {
+    describe("Number", () => {
+        specify("#[Eq.eq]", () => {
+            fc.assert(
+                fc.property(
+                    fc.float({ noNaN: true }),
+                    fc.float({ noNaN: true }),
+                    (x, y) => {
+                        expect(eq(x, y)).to.equal(x === y);
+                    },
+                ),
+            );
+        });
 
-    specify("[Ord.cmp]", () => {
-        fc.assert(
-            fc.property(
-                fc.float({ noNaN: true }),
-                fc.float({ noNaN: true }),
-                (x, y) => {
-                    const t0 = cmp(x, y);
-                    assert.strictEqual(
-                        t0,
-                        x < y
-                            ? Ordering.less
-                            : x > y
-                            ? Ordering.greater
-                            : Ordering.equal,
-                    );
-                },
-            ),
-        );
+        specify("#[Ord.cmp]", () => {
+            fc.assert(
+                fc.property(
+                    fc.float({ noNaN: true }),
+                    fc.float({ noNaN: true }),
+                    (x, y) => {
+                        expect(cmp(x, y)).to.equal(Ordering.fromNumber(x - y));
+                    },
+                ),
+            );
+        });
     });
 });

--- a/test/promise_test.ts
+++ b/test/promise_test.ts
@@ -1,16 +1,21 @@
 import { cmb } from "@neotype/prelude/cmb.js";
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import "../src/promise.js";
 import "../src/string.js";
 
-describe("Promise", () => {
-    specify("[Semigroup.cmb]", () => {
-        fc.assert(
-            fc.asyncProperty(fc.string(), fc.string(), async (x, y) => {
-                const t0 = await cmb(Promise.resolve(x), Promise.resolve(y));
-                assert.strictEqual(t0, cmb(x, y));
-            }),
-        );
+describe("promise.js", () => {
+    describe("Promise", () => {
+        specify("#[Semigroup.cmb]", async () => {
+            await fc.assert(
+                fc.asyncProperty(fc.string(), fc.string(), async (x, y) => {
+                    const result = await cmb(
+                        Promise.resolve(x),
+                        Promise.resolve(y),
+                    );
+                    expect(result).to.equal(cmb(x, y));
+                }),
+            );
+        });
     });
 });

--- a/test/set_test.ts
+++ b/test/set_test.ts
@@ -38,9 +38,13 @@ describe("set.js", () => {
                     fc.array(fc.anything()).map((xs) => new Set(xs)),
                     fc.array(fc.anything()).map((xs) => new Set(xs)),
                     (xs, ys) => {
-                        expect(cmb(xs, ys)).to.deep.equal(
-                            new Set([...xs, ...ys]),
-                        );
+                        const result = cmb(xs, ys);
+                        const exp = new Set([...xs, ...ys]);
+
+                        expect(result.size).to.equal(exp.size);
+                        for (const x of result) {
+                            expect(exp.has(x)).to.be.true;
+                        }
                     },
                 ),
             );

--- a/test/set_test.ts
+++ b/test/set_test.ts
@@ -1,40 +1,67 @@
 import { cmb } from "@neotype/prelude/cmb.js";
 import { eq } from "@neotype/prelude/cmp.js";
-import { assert } from "chai";
+import { expect } from "chai";
+import * as fc from "fast-check";
 import "../src/set.js";
 
-describe("Set", () => {
-    specify("[Eq.eq]", () => {
-        const t0 = eq(new Set([1, 2]), new Set([1, 2]));
-        assert.strictEqual(t0, true);
+describe("set.js", () => {
+    describe("Set", () => {
+        specify("#[Eq.eq]", () => {
+            fc.assert(
+                fc.property(
+                    fc.array(fc.anything()).map((xs) => new Set(xs)),
+                    fc.array(fc.anything()).map((xs) => new Set(xs)),
+                    (xs, ys) => {
+                        const result = eq(xs, ys);
 
-        const t1 = eq(new Set([1, 2]), new Set([2, 1]));
-        assert.strictEqual(t1, true);
+                        const exp = (() => {
+                            if (xs.size !== ys.size) {
+                                return false;
+                            }
+                            for (const x of xs) {
+                                if (!ys.has(x)) {
+                                    return false;
+                                }
+                            }
+                            return true;
+                        })();
 
-        const t2 = eq(new Set([1, 2]), new Set([1, 2, 3]));
-        assert.strictEqual(t2, false);
+                        expect(result).to.equal(exp);
+                    },
+                ),
+            );
+        });
 
-        const t3 = eq(new Set([1, 2]), new Set([1, 3]));
-        assert.strictEqual(t3, false);
-
-        const t4 = eq(new Set([1, 2]) as ReadonlySet<number>, new Set([1, 2]));
-        assert.strictEqual(t4, true);
-
-        const t5 = eq(new Set([1, 2]), new Set([1, 2]) as ReadonlySet<number>);
-        assert.strictEqual(t5, true);
+        specify("#[Semigroup.cmb]", () => {
+            fc.assert(
+                fc.property(
+                    fc.array(fc.anything()).map((xs) => new Set(xs)),
+                    fc.array(fc.anything()).map((xs) => new Set(xs)),
+                    (xs, ys) => {
+                        expect(cmb(xs, ys)).to.deep.equal(
+                            new Set([...xs, ...ys]),
+                        );
+                    },
+                ),
+            );
+        });
     });
 
-    specify("[Semigroup.cmb]", () => {
-        const t0 = cmb(new Set([1, 2]), new Set([1, 2]));
-        assert.deepEqual(t0, new Set([1, 2]));
+    describe("ReadonlySet", () => {
+        specify("#[Eq.eq]", () => {
+            const xs: ReadonlySet<unknown> = new Set();
+            const ys: Set<unknown> = new Set();
+            eq(xs, xs);
+            eq(xs, ys);
+            eq(ys, xs);
+        });
 
-        const t1 = cmb(new Set([1, 2]), new Set([1, 2, 3]));
-        assert.deepEqual(t1, new Set([1, 2, 3]));
-
-        const t2 = cmb(new Set([1, 2]) as ReadonlySet<number>, new Set([1, 2]));
-        assert.deepEqual(t2, new Set([1, 2]));
-
-        const t3 = cmb(new Set([1, 2]), new Set([1, 2]) as ReadonlySet<number>);
-        assert.deepEqual(t3, new Set([1, 2]));
+        specify("#[Semigroup.cmb]", () => {
+            const xs: ReadonlySet<unknown> = new Set();
+            const ys: Set<unknown> = new Set();
+            cmb(xs, xs);
+            cmb(xs, ys);
+            cmb(ys, xs);
+        });
     });
 });

--- a/test/string_test.ts
+++ b/test/string_test.ts
@@ -1,41 +1,39 @@
 import { cmb } from "@neotype/prelude/cmb.js";
 import { cmp, eq, Ordering } from "@neotype/prelude/cmp.js";
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import "../src/string.js";
 
-describe("string", () => {
-    specify("[Eq.eq]", () => {
-        fc.assert(
-            fc.property(fc.string(), fc.string(), (x, y) => {
-                const t0 = eq(x, y);
-                assert.strictEqual(t0, x === y);
-            }),
-        );
-    });
+describe("string.js", () => {
+    describe("String", () => {
+        specify("#[Eq.eq]", () => {
+            fc.assert(
+                fc.property(fc.string(), fc.string(), (x, y) => {
+                    expect(eq(x, y)).to.equal(x === y);
+                }),
+            );
+        });
 
-    specify("[Ord.cmp]", () => {
-        fc.assert(
-            fc.property(fc.string(), fc.string(), (x, y) => {
-                const t0 = cmp(x, y);
-                assert.strictEqual(
-                    t0,
-                    x < y
-                        ? Ordering.less
-                        : x > y
-                        ? Ordering.greater
-                        : Ordering.equal,
-                );
-            }),
-        );
-    });
+        specify("#[Ord.cmp]", () => {
+            fc.assert(
+                fc.property(fc.string(), fc.string(), (x, y) => {
+                    expect(cmp(x, y)).to.equal(
+                        x < y
+                            ? Ordering.less
+                            : x > y
+                            ? Ordering.greater
+                            : Ordering.equal,
+                    );
+                }),
+            );
+        });
 
-    specify("[Semigroup.cmb]", () => {
-        fc.assert(
-            fc.property(fc.string(), fc.string(), (x, y) => {
-                const t0 = cmb(x, y);
-                assert.strictEqual(t0, x + y);
-            }),
-        );
+        specify("#[Semigroup.cmb]", () => {
+            fc.assert(
+                fc.property(fc.string(), fc.string(), (x, y) => {
+                    expect(cmb(x, y)).to.equal(x + y);
+                }),
+            );
+        });
     });
 });

--- a/test/symbol_test.ts
+++ b/test/symbol_test.ts
@@ -1,14 +1,18 @@
 import { eq } from "@neotype/prelude/cmp.js";
-import { assert } from "chai";
+import { expect } from "chai";
 import "../src/symbol.js";
 
-describe("symbol", () => {
-    specify("[Eq.eq]", () => {
-        const s0 = Symbol() as symbol;
-        const s1 = Symbol() as symbol;
-        assert.strictEqual(eq(s0, s0), true);
-        assert.strictEqual(eq(s0, s1), false);
-        assert.strictEqual(eq(s1, s0), false);
-        assert.strictEqual(eq(s1, s1), true);
+describe("symbol.js", () => {
+    describe("Symbol", () => {
+        describe("#[Eq.eq]", () => {
+            it("compares a symbol as equal to itself", () => {
+                const sym = Symbol();
+                expect(eq(sym, sym)).to.be.true;
+            });
+
+            it("compares two different symbols as inequal", () => {
+                expect(eq(Symbol(), Symbol())).to.be.false;
+            });
+        });
     });
 });

--- a/test/uint16_array_test.ts
+++ b/test/uint16_array_test.ts
@@ -1,44 +1,44 @@
 import { cmb } from "@neotype/prelude/cmb.js";
 import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import "../src/uint16_array.js";
 
-describe("Uint16Array", () => {
-    specify("[Eq.eq]", () => {
-        fc.assert(
-            fc.property(fc.uint16Array(), fc.uint16Array(), (xs, ys) => {
-                const t0 = eq(xs, ys);
-                assert.strictEqual(
-                    t0,
-                    ieqBy(xs, ys, (x, y) => x === y),
-                );
-            }),
-        );
-    });
+describe("uint16_array.js", () => {
+    describe("Uint16Array", () => {
+        specify("#[Eq.eq]", () => {
+            fc.assert(
+                fc.property(fc.uint16Array(), fc.uint16Array(), (xs, ys) => {
+                    expect(eq(xs, ys)).to.equal(
+                        ieqBy(xs, ys, (x, y) => x === y),
+                    );
+                }),
+            );
+        });
 
-    specify("[Ord.cmp]", () => {
-        fc.assert(
-            fc.property(fc.uint16Array(), fc.uint16Array(), (xs, ys) => {
-                const t0 = cmp(xs, ys);
-                assert.strictEqual(
-                    t0,
-                    icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
-                );
-            }),
-        );
-    });
+        specify("#[Ord.cmp]", () => {
+            fc.assert(
+                fc.property(fc.uint16Array(), fc.uint16Array(), (xs, ys) => {
+                    expect(cmp(xs, ys)).to.equal(
+                        icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+                    );
+                }),
+            );
+        });
 
-    specify("[Semigroup.cmb]", () => {
-        fc.assert(
-            fc.property(fc.uint16Array(), fc.uint16Array(), (xs, ys) => {
-                const t0 = cmb(xs, ys);
-                const exp = new Uint16Array(xs.length + ys.length);
-                exp.set(xs);
-                exp.set(ys, xs.length);
-                assert.deepEqual(t0, exp);
-                assert.strictEqual(exp.length, xs.length + ys.length);
-            }),
-        );
+        specify("#[Semigroup.cmb]", () => {
+            fc.assert(
+                fc.property(fc.uint16Array(), fc.uint16Array(), (xs, ys) => {
+                    const result = cmb(xs, ys);
+
+                    const exp = new Uint16Array(xs.length + ys.length);
+                    exp.set(xs);
+                    exp.set(ys, xs.length);
+
+                    expect(result).to.deep.equal(exp);
+                    expect(exp.length).to.equal(xs.length + ys.length);
+                }),
+            );
+        });
     });
 });

--- a/test/uint32_array_test.ts
+++ b/test/uint32_array_test.ts
@@ -1,44 +1,44 @@
 import { cmb } from "@neotype/prelude/cmb.js";
 import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import "../src/uint32_array.js";
 
-describe("Uint32Array", () => {
-    specify("[Eq.eq]", () => {
-        fc.assert(
-            fc.property(fc.uint32Array(), fc.uint32Array(), (xs, ys) => {
-                const t0 = eq(xs, ys);
-                assert.strictEqual(
-                    t0,
-                    ieqBy(xs, ys, (x, y) => x === y),
-                );
-            }),
-        );
-    });
+describe("uint32_array.js", () => {
+    describe("Uint32Array", () => {
+        specify("#[Eq.eq]", () => {
+            fc.assert(
+                fc.property(fc.uint32Array(), fc.uint32Array(), (xs, ys) => {
+                    expect(eq(xs, ys)).to.equal(
+                        ieqBy(xs, ys, (x, y) => x === y),
+                    );
+                }),
+            );
+        });
 
-    specify("[Ord.cmp]", () => {
-        fc.assert(
-            fc.property(fc.uint32Array(), fc.uint32Array(), (xs, ys) => {
-                const t0 = cmp(xs, ys);
-                assert.strictEqual(
-                    t0,
-                    icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
-                );
-            }),
-        );
-    });
+        specify("#[Ord.cmp]", () => {
+            fc.assert(
+                fc.property(fc.uint32Array(), fc.uint32Array(), (xs, ys) => {
+                    expect(cmp(xs, ys)).to.equal(
+                        icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+                    );
+                }),
+            );
+        });
 
-    specify("[Semigroup.cmb]", () => {
-        fc.assert(
-            fc.property(fc.uint32Array(), fc.uint32Array(), (xs, ys) => {
-                const t0 = cmb(xs, ys);
-                const exp = new Uint32Array(xs.length + ys.length);
-                exp.set(xs);
-                exp.set(ys, xs.length);
-                assert.deepEqual(t0, exp);
-                assert.strictEqual(exp.length, xs.length + ys.length);
-            }),
-        );
+        specify("#[Semigroup.cmb]", () => {
+            fc.assert(
+                fc.property(fc.uint32Array(), fc.uint32Array(), (xs, ys) => {
+                    const result = cmb(xs, ys);
+
+                    const exp = new Uint32Array(xs.length + ys.length);
+                    exp.set(xs);
+                    exp.set(ys, xs.length);
+
+                    expect(result).to.deep.equal(exp);
+                    expect(exp.length).to.equal(xs.length + ys.length);
+                }),
+            );
+        });
     });
 });

--- a/test/uint8_array_test.ts
+++ b/test/uint8_array_test.ts
@@ -1,44 +1,44 @@
 import { cmb } from "@neotype/prelude/cmb.js";
 import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import "../src/uint8_array.js";
 
-describe("Uint8Array", () => {
-    specify("[Eq.eq]", () => {
-        fc.assert(
-            fc.property(fc.uint8Array(), fc.uint8Array(), (xs, ys) => {
-                const t0 = eq(xs, ys);
-                assert.strictEqual(
-                    t0,
-                    ieqBy(xs, ys, (x, y) => x === y),
-                );
-            }),
-        );
-    });
+describe("uint8_array.js", () => {
+    describe("Uint8Array", () => {
+        specify("#[Eq.eq]", () => {
+            fc.assert(
+                fc.property(fc.uint8Array(), fc.uint8Array(), (xs, ys) => {
+                    expect(eq(xs, ys)).to.equal(
+                        ieqBy(xs, ys, (x, y) => x === y),
+                    );
+                }),
+            );
+        });
 
-    specify("[Ord.cmp]", () => {
-        fc.assert(
-            fc.property(fc.uint8Array(), fc.uint8Array(), (xs, ys) => {
-                const t0 = cmp(xs, ys);
-                assert.strictEqual(
-                    t0,
-                    icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
-                );
-            }),
-        );
-    });
+        specify("#[Ord.cmp]", () => {
+            fc.assert(
+                fc.property(fc.uint8Array(), fc.uint8Array(), (xs, ys) => {
+                    expect(cmp(xs, ys)).to.equal(
+                        icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+                    );
+                }),
+            );
+        });
 
-    specify("[Semigroup.cmb]", () => {
-        fc.assert(
-            fc.property(fc.uint8Array(), fc.uint8Array(), (xs, ys) => {
-                const t0 = cmb(xs, ys);
-                const exp = new Uint8Array(xs.length + ys.length);
-                exp.set(xs);
-                exp.set(ys, xs.length);
-                assert.deepEqual(t0, exp);
-                assert.strictEqual(exp.length, xs.length + ys.length);
-            }),
-        );
+        specify("#[Semigroup.cmb]", () => {
+            fc.assert(
+                fc.property(fc.uint8Array(), fc.uint8Array(), (xs, ys) => {
+                    const result = cmb(xs, ys);
+
+                    const exp = new Uint8Array(xs.length + ys.length);
+                    exp.set(xs);
+                    exp.set(ys, xs.length);
+
+                    expect(result).to.deep.equal(exp);
+                    expect(exp.length).to.equal(xs.length + ys.length);
+                }),
+            );
+        });
     });
 });

--- a/test/uint8_clamped_array_test.ts
+++ b/test/uint8_clamped_array_test.ts
@@ -1,56 +1,60 @@
 import { cmb } from "@neotype/prelude/cmb.js";
 import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import "../src/uint8_clamped_array.js";
 
-describe("Uint8ClampedArray", () => {
-    specify("[Eq.eq]", () => {
-        fc.assert(
-            fc.property(
-                fc.uint8ClampedArray(),
-                fc.uint8ClampedArray(),
-                (xs, ys) => {
-                    const t0 = eq(xs, ys);
-                    assert.strictEqual(
-                        t0,
-                        ieqBy(xs, ys, (x, y) => x === y),
-                    );
-                },
-            ),
-        );
-    });
+describe("uint8_clamped_array.js", () => {
+    describe("Uint8ClampedArray", () => {
+        specify("#[Eq.eq]", () => {
+            fc.assert(
+                fc.property(
+                    fc.uint8ClampedArray(),
+                    fc.uint8ClampedArray(),
+                    (xs, ys) => {
+                        expect(eq(xs, ys)).to.equal(
+                            ieqBy(xs, ys, (x, y) => x === y),
+                        );
+                    },
+                ),
+            );
+        });
 
-    specify("[Ord.cmp]", () => {
-        fc.assert(
-            fc.property(
-                fc.uint8ClampedArray(),
-                fc.uint8ClampedArray(),
-                (xs, ys) => {
-                    const t0 = cmp(xs, ys);
-                    assert.strictEqual(
-                        t0,
-                        icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
-                    );
-                },
-            ),
-        );
-    });
+        specify("#[Ord.cmp]", () => {
+            fc.assert(
+                fc.property(
+                    fc.uint8ClampedArray(),
+                    fc.uint8ClampedArray(),
+                    (xs, ys) => {
+                        expect(cmp(xs, ys)).to.equal(
+                            icmpBy(xs, ys, (x, y) =>
+                                Ordering.fromNumber(x - y),
+                            ),
+                        );
+                    },
+                ),
+            );
+        });
 
-    specify("[Semigroup.cmb]", () => {
-        fc.assert(
-            fc.property(
-                fc.uint8ClampedArray(),
-                fc.uint8ClampedArray(),
-                (xs, ys) => {
-                    const t0 = cmb(xs, ys);
-                    const exp = new Uint8ClampedArray(xs.length + ys.length);
-                    exp.set(xs);
-                    exp.set(ys, xs.length);
-                    assert.deepEqual(t0, exp);
-                    assert.strictEqual(exp.length, xs.length + ys.length);
-                },
-            ),
-        );
+        specify("#[Semigroup.cmb]", () => {
+            fc.assert(
+                fc.property(
+                    fc.uint8ClampedArray(),
+                    fc.uint8ClampedArray(),
+                    (xs, ys) => {
+                        const result = cmb(xs, ys);
+
+                        const exp = new Uint8ClampedArray(
+                            xs.length + ys.length,
+                        );
+                        exp.set(xs);
+                        exp.set(ys, xs.length);
+
+                        expect(result).to.deep.equal(exp);
+                        expect(exp.length).to.equal(xs.length + ys.length);
+                    },
+                ),
+            );
+        });
     });
 });


### PR DESCRIPTION
- Use `describe` and `it` blocks
- From Chai, replace the `assert` API with the `expect` API