### PR TITLE
Require an `Eq` implemention from values in maps

### DIFF
--- a/src/map.ts
+++ b/src/map.ts
@@ -49,23 +49,26 @@
  */
 
 import { Semigroup } from "@neotype/prelude/cmb.js";
-import { Eq } from "@neotype/prelude/cmp.js";
+import { Eq, eq } from "@neotype/prelude/cmp.js";
 
 declare global {
     interface Map<K, V> {
-        [Eq.eq](that: Map<K, V>): boolean;
+        [Eq.eq]<V extends Eq<V>>(this: Map<K, V>, that: Map<K, V>): boolean;
 
         [Semigroup.cmb](that: Map<K, V>): Map<K, V>;
     }
 
     interface ReadonlyMap<K, V> {
-        [Eq.eq](that: ReadonlyMap<K, V>): boolean;
+        [Eq.eq]<V extends Eq<V>>(
+            this: ReadonlyMap<K, V>,
+            that: ReadonlyMap<K, V>,
+        ): boolean;
 
         [Semigroup.cmb](that: ReadonlyMap<K, V>): ReadonlyMap<K, V>;
     }
 }
 
-Map.prototype[Eq.eq] = function <K, V>(
+Map.prototype[Eq.eq] = function <K, V extends Eq<V>>(
     this: Map<K, V>,
     that: Map<K, V>,
 ): boolean {
@@ -73,7 +76,8 @@ Map.prototype[Eq.eq] = function <K, V>(
         return false;
     }
     for (const [kx, x] of this.entries()) {
-        if (!(that.has(kx) && that.get(kx) === x)) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        if (!(that.has(kx) && eq(that.get(kx)!, x))) {
             return false;
         }
     }

--- a/test/map_test.ts
+++ b/test/map_test.ts
@@ -3,6 +3,7 @@ import { eq } from "@neotype/prelude/cmp.js";
 import { expect } from "chai";
 import * as fc from "fast-check";
 import "../src/map.js";
+import "../src/string.js";
 
 describe("map.js", () => {
     describe("Map", () => {
@@ -10,10 +11,10 @@ describe("map.js", () => {
             fc.assert(
                 fc.property(
                     fc
-                        .array(fc.tuple(fc.anything(), fc.anything()))
+                        .array(fc.tuple(fc.anything(), fc.string()))
                         .map((entries) => new Map(entries)),
                     fc
-                        .array(fc.tuple(fc.anything(), fc.anything()))
+                        .array(fc.tuple(fc.anything(), fc.string()))
                         .map((entries) => new Map(entries)),
                     (xs, ys) => {
                         const result = eq(xs, ys);
@@ -23,7 +24,8 @@ describe("map.js", () => {
                                 return false;
                             }
                             for (const [kx, x] of xs.entries()) {
-                                if (!(ys.has(kx) && ys.get(kx) === x)) {
+                                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                                if (!(ys.has(kx) && eq(ys.get(kx)!, x))) {
                                     return false;
                                 }
                             }
@@ -62,8 +64,8 @@ describe("map.js", () => {
 
     describe("ReadonlyMap", () => {
         specify("#[Eq.eq]", () => {
-            const xs: ReadonlyMap<unknown, unknown> = new Map();
-            const ys: Map<unknown, unknown> = new Map();
+            const xs: ReadonlyMap<unknown, string> = new Map();
+            const ys: Map<unknown, string> = new Map();
             eq(xs, xs);
             eq(xs, ys);
             eq(ys, xs);


### PR DESCRIPTION
For the `Map` and `ReadonlyMap` equivalence relations, require that the values also implement `Eq`.