### PR TITLE
In the test for `Map#[Semigroup.cmb]`, use a deep equality check

### DIFF
--- a/test/map_test.ts
+++ b/test/map_test.ts
@@ -54,7 +54,7 @@ describe("map.js", () => {
                         expect(result.size).to.equal(exp.size);
                         for (const [kx, x] of result) {
                             expect(exp.has(kx)).to.be.true;
-                            expect(exp.get(kx)).to.equal(x);
+                            expect(exp.get(kx)).to.deep.equal(x);
                         }
                     },
                 ),


### PR DESCRIPTION
Compare the expected values of the maps using deep equality instead of strict equality to avoid errors when comparing `NaN`.